### PR TITLE
-Fixing IE problem -Problems with inserts of additional webparts -Missing translation text only visible in development mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ A list of core service to ease Wizdom development
 ## Vue.js
 Wizdom product development use [Vue.js](https://vuejs.org/).
 Specific vue service class are available.
+
+# Development
+npm run build:watch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.0.1",
+    "version": "1.1.1",
     "description": "A list of core service to ease Wizdom development",
     "main": "dist/index.js",
     "types": "dist/main.d.ts",

--- a/samples/spfxwebpart/README.md
+++ b/samples/spfxwebpart/README.md
@@ -18,7 +18,7 @@ It requires tenant properties:
 
 ### Install @Wizdom/services
 If changes are made to @wizdom/service a force installation can be done with following command:
-npm install @wizdom/services --force
+npm install @wizdom-intranet/services --force
 
 Recommended for development:
 Use npm link

--- a/samples/spfxwebpart/package-lock.json
+++ b/samples/spfxwebpart/package-lock.json
@@ -2342,7 +2342,7 @@
         "tslib": "1.8.1"
       }
     },
-    "@wizdom/services": {
+    "@wizdom-intranet/services": {
       "version": "file:../..",
       "requires": {
         "@microsoft/sp-application-base": "1.5.1",
@@ -2829,6 +2829,17 @@
         },
         "array-reduce": {
           "version": "0.0.0",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "1.0.3"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
           "bundled": true
         },
         "array-unique": {
@@ -3504,6 +3515,23 @@
           "version": "1.0.2",
           "bundled": true
         },
+        "cp-file": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "nested-error-stacks": "2.0.1",
+            "pify": "3.0.0",
+            "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
         "cpx": {
           "version": "1.5.0",
           "bundled": true,
@@ -3519,6 +3547,16 @@
             "safe-buffer": "5.1.2",
             "shell-quote": "1.6.1",
             "subarg": "1.0.0"
+          }
+        },
+        "cpy": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "cp-file": "5.0.0",
+            "globby": "6.1.0",
+            "nested-error-stacks": "2.0.1"
           }
         },
         "create-react-class": {
@@ -4205,6 +4243,17 @@
           "version": "9.18.0",
           "bundled": true
         },
+        "globby": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true
@@ -4473,16 +4522,16 @@
             "is-extglob": "1.0.0"
           }
         },
-        "is-module": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "is-number": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
             "kind-of": "3.2.2"
           }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
         },
         "is-plain-object": {
           "version": "2.0.4",
@@ -5070,6 +5119,10 @@
           "version": "1.3.0",
           "bundled": true
         },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "json-schema": {
           "version": "0.2.3",
           "bundled": true
@@ -5182,6 +5235,10 @@
           "version": "4.5.0",
           "bundled": true
         },
+        "lodash.isobject": {
+          "version": "3.0.2",
+          "bundled": true
+        },
         "lodash.sortby": {
           "version": "4.7.0",
           "bundled": true
@@ -5205,11 +5262,17 @@
             "yallist": "2.1.2"
           }
         },
-        "magic-string": {
-          "version": "0.22.5",
+        "make-dir": {
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "vlq": "0.2.3"
+            "pify": "3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
           }
         },
         "makeerror": {
@@ -5276,10 +5339,6 @@
               "bundled": true
             }
           }
-        },
-        "mime": {
-          "version": "1.6.0",
-          "bundled": true
         },
         "mime-db": {
           "version": "1.33.0",
@@ -5364,6 +5423,10 @@
         },
         "natural-compare": {
           "version": "1.4.0",
+          "bundled": true
+        },
+        "nested-error-stacks": {
+          "version": "2.0.1",
           "bundled": true
         },
         "node-cache": {
@@ -5518,10 +5581,6 @@
           "requires": {
             "wrappy": "1.0.2"
           }
-        },
-        "opener": {
-          "version": "1.4.3",
-          "bundled": true
         },
         "optimist": {
           "version": "0.6.1",
@@ -6014,47 +6073,70 @@
           "version": "0.50.1",
           "bundled": true
         },
-        "rollup-plugin-commonjs": {
-          "version": "8.4.1",
+        "rollup-plugin-cpy": {
+          "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "acorn": "5.7.1",
-            "estree-walker": "0.5.2",
-            "magic-string": "0.22.5",
-            "resolve": "1.8.1",
-            "rollup-pluginutils": "2.3.0"
+            "chalk": "2.4.1",
+            "cpy": "6.0.0",
+            "lodash.isobject": "3.0.2",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "rollup-plugin-generate-package-json": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "read-pkg": "3.0.0",
+            "write-pkg": "3.2.0"
           },
           "dependencies": {
-            "resolve": {
-              "version": "1.8.1",
+            "load-json-file": {
+              "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "path-parse": "1.0.5"
+                "graceful-fs": "4.1.11",
+                "parse-json": "4.0.0",
+                "pify": "3.0.0",
+                "strip-bom": "3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "1.3.2",
+                "json-parse-better-errors": "1.0.2"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "4.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "3.0.0"
               }
             }
           }
         },
-        "rollup-plugin-node-resolve": {
-          "version": "3.3.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "2.0.0",
-            "is-module": "1.0.0",
-            "resolve": "1.1.7"
-          },
-          "dependencies": {
-            "builtin-modules": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "rollup-plugin-serve": {
+        "rollup-plugin-sourcemaps": {
           "version": "0.4.2",
           "bundled": true,
           "requires": {
-            "mime": "1.6.0",
-            "opener": "1.4.3"
+            "rollup-pluginutils": "2.3.0",
+            "source-map-resolve": "0.5.2"
           }
         },
         "rollup-plugin-typescript2": {
@@ -6338,6 +6420,13 @@
           "bundled": true,
           "requires": {
             "kind-of": "3.2.2"
+          }
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-plain-obj": "1.1.0"
           }
         },
         "source-map": {
@@ -7033,10 +7122,6 @@
             "extsprintf": "1.3.0"
           }
         },
-        "vlq": {
-          "version": "0.2.3",
-          "bundled": true
-        },
         "vue-jest": {
           "version": "2.6.0",
           "bundled": true,
@@ -7182,6 +7267,36 @@
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
             "signal-exit": "3.0.2"
+          }
+        },
+        "write-json-file": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "detect-indent": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.3.0",
+            "pify": "3.0.0",
+            "sort-keys": "2.0.0",
+            "write-file-atomic": "2.3.0"
+          },
+          "dependencies": {
+            "detect-indent": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "write-pkg": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "sort-keys": "2.0.0",
+            "write-json-file": "2.3.0"
           }
         },
         "ws": {

--- a/samples/spfxwebpart/package.json
+++ b/samples/spfxwebpart/package.json
@@ -17,7 +17,7 @@
     "@microsoft/sp-webpart-base": "1.5.1",
     "@types/es6-promise": "0.0.33",
     "@types/webpack-env": "1.13.1",
-    "@wizdom/services": "file:../.."
+    "@wizdom-intranet/services": "file:../.."  
   },
   "devDependencies": {
     "@microsoft/sp-build-web": "1.5.1",

--- a/samples/spfxwebpart/src/webparts/wizdomServiceTest/WizdomServiceTestWebPart.ts
+++ b/samples/spfxwebpart/src/webparts/wizdomServiceTest/WizdomServiceTestWebPart.ts
@@ -19,43 +19,45 @@ export default class WizdomServiceTestWebPart extends BaseClientSideWebPart<IWiz
     private wizdomServices: WizdomSpfxServices;
 
   public async render(): Promise<void> {
-    // Initialization
-    this.wizdomServices = new WizdomSpfxServices(this.context);
-    await this.wizdomServices.InitAsync({});
+    if(!this.renderedOnce) {
+        // Initialization
+        this.wizdomServices = new WizdomSpfxServices(this.context);
+        await this.wizdomServices.InitAsync({});
 
-    // Usage
-    var wizdomConfiguration = this.wizdomServices.WizdomConfiguration;
-    var wizdomContext = this.wizdomServices.WizdomContext
-    var wizdomTranslationService = this.wizdomServices.TranslationService;    
+        // Usage
+        var wizdomConfiguration = this.wizdomServices.WizdomConfiguration;
+        var wizdomContext = this.wizdomServices.WizdomContext
+        var wizdomTranslationService = this.wizdomServices.TranslationService;    
 
-    this.wizdomServices.WizdomWebApiService.Get("api/wizdom/365/principals/me").then(result => {        
-        alert("Me: " + JSON.stringify(result));
-    });
+        this.wizdomServices.WizdomWebApiService.Get("api/wizdom/365/principals/me").then(result => {        
+            alert("Me: " + JSON.stringify(result));
+        });
 
-    var createdByText = wizdomTranslationService.translate("Created by") + " Wizdom";
+        var createdByText = wizdomTranslationService.translate("Created by") + " Wizdom";
 
-    this.domElement.innerHTML = `
-    <div class="${ styles.wizdomServiceTest }" style="height:500px; overflow:hidden;">
-        <div class="${ styles.container }">
-        <div class="${ styles.row }">
-            <div class="${ styles.column }">
-            <span class="${ styles.title }">Wizdom service no framework sample!</span>
-            <p class="${ styles.description }">
-                <b>Wizdom Translation</b><br/>
-                ${createdByText}                
-            </p>     
-            <p class="${ styles.description }">
-                <b>Wizdom Context</b><br/>
-                ${JSON.stringify(wizdomContext)}
-            </p>
-            <p class="${ styles.description }">
-                <b>Wizdom Configuration</b><br/>                
-                ${JSON.stringify(wizdomConfiguration)}                
-            </p>              
+        this.domElement.innerHTML = `
+        <div class="${ styles.wizdomServiceTest }" style="height:500px; overflow:hidden;">
+            <div class="${ styles.container }">
+            <div class="${ styles.row }">
+                <div class="${ styles.column }">
+                <span class="${ styles.title }">Wizdom service no framework sample!</span>
+                <p class="${ styles.description }">
+                    <b>Wizdom Translation</b><br/>
+                    ${createdByText}                
+                </p>     
+                <p class="${ styles.description }">
+                    <b>Wizdom Context</b><br/>
+                    ${JSON.stringify(wizdomContext)}
+                </p>
+                <p class="${ styles.description }">
+                    <b>Wizdom Configuration</b><br/>                
+                    ${JSON.stringify(wizdomConfiguration)}                
+                </p>              
+                </div>
             </div>
-        </div>
-        </div>
-    </div>`;      
+            </div>
+        </div>`;      
+    }
   }
 
   protected get dataVersion(): Version {
@@ -73,8 +75,8 @@ export default class WizdomServiceTestWebPart extends BaseClientSideWebPart<IWiz
             {
               groupName: strings.BasicGroupName,
               groupFields: [
-                PropertyPaneTextField(this.wizdomServices.TranslationService.translate('description'), {
-                  label: strings.DescriptionFieldLabel
+                PropertyPaneTextField('description', {
+                  label: this.wizdomServices.TranslationService.translate(strings.DescriptionFieldLabel)
                 })
               ]
             }

--- a/samples/spfxwebpart/src/webparts/wizdomServiceTest/WizdomServiceTestWebPart.ts
+++ b/samples/spfxwebpart/src/webparts/wizdomServiceTest/WizdomServiceTestWebPart.ts
@@ -9,53 +9,53 @@ import { escape } from '@microsoft/sp-lodash-subset';
 import styles from './WizdomServiceTestWebPart.module.scss';
 import * as strings from 'WizdomServiceTestWebPartStrings';
 
-import { WizdomSpfxServices } from "@wizdom/services";
+import { WizdomSpfxServices } from "@wizdom-intranet/services";
 
 export interface IWizdomServiceTestWebPartProps {
   description: string;
 }
 
 export default class WizdomServiceTestWebPart extends BaseClientSideWebPart<IWizdomServiceTestWebPartProps> {
+    private wizdomServices: WizdomSpfxServices;
 
   public async render(): Promise<void> {
-
     // Initialization
-    var wizdomServices = new WizdomSpfxServices(this.context);
-    await wizdomServices.InitAsync({});
+    this.wizdomServices = new WizdomSpfxServices(this.context);
+    await this.wizdomServices.InitAsync({});
 
     // Usage
-    var wizdomConfiguration = wizdomServices.WizdomConfiguration;
-    var wizdomContext = wizdomServices.WizdomContext
-    var wizdomTranslationService = wizdomServices.TranslationService;    
-    
-    wizdomServices.WizdomWebApiService.Get("api/wizdom/365/principals/me").then(result => {        
+    var wizdomConfiguration = this.wizdomServices.WizdomConfiguration;
+    var wizdomContext = this.wizdomServices.WizdomContext
+    var wizdomTranslationService = this.wizdomServices.TranslationService;    
+
+    this.wizdomServices.WizdomWebApiService.Get("api/wizdom/365/principals/me").then(result => {        
         alert("Me: " + JSON.stringify(result));
     });
 
     var createdByText = wizdomTranslationService.translate("Created by") + " Wizdom";
 
     this.domElement.innerHTML = `
-      <div class="${ styles.wizdomServiceTest }" style="height:500px; overflow:hidden;">
+    <div class="${ styles.wizdomServiceTest }" style="height:500px; overflow:hidden;">
         <div class="${ styles.container }">
-          <div class="${ styles.row }">
+        <div class="${ styles.row }">
             <div class="${ styles.column }">
-              <span class="${ styles.title }">Wizdom service no framework sample!</span>
-              <p class="${ styles.description }">
+            <span class="${ styles.title }">Wizdom service no framework sample!</span>
+            <p class="${ styles.description }">
                 <b>Wizdom Translation</b><br/>
                 ${createdByText}                
-              </p>     
-              <p class="${ styles.description }">
+            </p>     
+            <p class="${ styles.description }">
                 <b>Wizdom Context</b><br/>
                 ${JSON.stringify(wizdomContext)}
-              </p>
-              <p class="${ styles.description }">
+            </p>
+            <p class="${ styles.description }">
                 <b>Wizdom Configuration</b><br/>                
                 ${JSON.stringify(wizdomConfiguration)}                
-              </p>              
+            </p>              
             </div>
-          </div>
         </div>
-      </div>`;      
+        </div>
+    </div>`;      
   }
 
   protected get dataVersion(): Version {
@@ -73,7 +73,7 @@ export default class WizdomServiceTestWebPart extends BaseClientSideWebPart<IWiz
             {
               groupName: strings.BasicGroupName,
               groupFields: [
-                PropertyPaneTextField('description', {
+                PropertyPaneTextField(this.wizdomServices.TranslationService.translate('description'), {
                   label: strings.DescriptionFieldLabel
                 })
               ]

--- a/src/services/context/context.factory.ts
+++ b/src/services/context/context.factory.ts
@@ -4,7 +4,7 @@ import { IHttpClient } from "../../shared/httpclient.wrappers/http.interfaces";
 
 export class WizdomContextFactory {
 
-    constructor(private spHttpClient: IHttpClient, private cache: IWizdomCache) {        
+    constructor(private spHttpClient: IHttpClient, private cache: IWizdomCache, private wizdomdevelopermode: boolean) {        
     }
 
     GetWizdomContextAsync(siteAbsoluteUrl: string): Promise<IWizdomContext> {
@@ -28,9 +28,11 @@ export class WizdomContextFactory {
         },  expireIn, refreshIn, refreshDelayIn)
     
         .then((context) => {
-            // Store a global variable
-            window["WizdomContext"] = context;
-            return context as IWizdomContext;
+            // Store a global variable                       
+            var wizdomContext = context as IWizdomContext;            
+            wizdomContext.wizdomdevelopermode = this.wizdomdevelopermode;
+            window["WizdomContext"] = wizdomContext;
+            return wizdomContext;
         });
     }
 }

--- a/src/services/context/context.interfaces.ts
+++ b/src/services/context/context.interfaces.ts
@@ -2,4 +2,5 @@ export interface IWizdomContext {
     appUrl: string;
     blobUrl: string;
     clientId: string;
+    wizdomdevelopermode: boolean;
 } 

--- a/src/services/corsproxy/corsproxy.interfaces.ts
+++ b/src/services/corsproxy/corsproxy.interfaces.ts
@@ -1,5 +1,5 @@
 export interface IWizdomCorsProxyServiceFactory {
-    Create(recreate: boolean): IWizdomCorsProxyService;
+    GetOrCreate(recreate: boolean): IWizdomCorsProxyService;
 }
 
 export interface IWizdomCorsProxyService {

--- a/src/services/corsproxy/corsproxy.service.factory.ts
+++ b/src/services/corsproxy/corsproxy.service.factory.ts
@@ -10,11 +10,15 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
         this.addEventListeners();   
     }
 
-    Create(recreate: boolean = false) : IWizdomCorsProxyService {
-        let frame = this.getOrCreateIFrame(recreate);
+    GetOrCreate(recreate: boolean = false) : IWizdomCorsProxyService {
+        var frame = this.getOrCreateIFrame(recreate);
         this.frameService = new WizdomCorsProxyService(frame, this.getCorsProxySharedState());
-
         return this.frameService;
+    }
+
+    private endsWith(str, suffix) : boolean {
+        // using this endswith method to support IE
+        return str.indexOf(suffix, str.length - suffix.length) !== -1;
     }
 
     private getOrCreateIFrame(recreate: boolean = false) : IWizdomCorsProxyIframe {     
@@ -23,12 +27,11 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
             var corsProxyIframe = document.createElement("iframe");
             corsProxyIframe.style.display = "none";
             
-            var appUrl = this.context.appUrl.endsWith("/") ? this.context.appUrl : this.context.appUrl + "/";
+            var appUrl = this.endsWith(this.context.appUrl, "/") ? this.context.appUrl : this.context.appUrl + "/";
             corsProxyIframe.src = this.spHostUrl + "/_layouts/15/appredirect.aspx?client_id=" + this.context.clientId + "&redirect_uri=" + appUrl + "Base/WizdomCorsProxy.aspx?{StandardTokens}" + "%26userLoginName=" + encodeURIComponent(this.userLoginName);            
 
             document.body.appendChild(corsProxyIframe);
        
-
             window["WizdomCorsProxy"] = corsProxyIframe;
         }
         return window["WizdomCorsProxy"]["contentWindow"];

--- a/src/services/translations/__tests__/translation.service.factory.spec.ts
+++ b/src/services/translations/__tests__/translation.service.factory.spec.ts
@@ -48,7 +48,8 @@ describe("WizdomTranslationServiceFactory", () => {
         testWizdomContext = {
             appUrl: "",
             blobUrl: "",
-            clientId: ""
+            clientId: "",
+            wizdomdevelopermode: false
         } as IWizdomContext;
     });
 

--- a/src/services/translations/__tests__/translation.service.spec.ts
+++ b/src/services/translations/__tests__/translation.service.spec.ts
@@ -11,17 +11,38 @@ describe("WizdomTranslationService", () => {
         expect('correct value').toEqual(actual);
     });
 
-    it("should return missing translation if key does not exist", () => {
+    it("should return translation key if key does not exist", () => {
+        var developmentmode = false;        
         var sut = new WizdomTranslationService({            
-        });
+        }, developmentmode);
+        
+        var actual = sut.translate("test");
+
+        expect('test').toEqual(actual);
+    });
+
+    it("should return translation key if service not initialized correct", () => {    
+        var developmentmode = false;
+        var sut = new WizdomTranslationService(null, developmentmode);
+        
+        var actual = sut.translate("test");   
+
+        expect('test').toEqual(actual);
+    });
+
+    it("should return missing translation if key does not exist", () => {
+        var developmentmode = true;
+        var sut = new WizdomTranslationService({            
+        }, developmentmode);
         
         var actual = sut.translate("test");
 
         expect('[Translation missing: test]').toEqual(actual);
     });
 
-    it("should return error translation if service not initialized correct", () => {    
-        var sut = new WizdomTranslationService(null);
+    it("should return error translation if service not initialized correct", () => {  
+        var developmentmode = true;  
+        var sut = new WizdomTranslationService(null, developmentmode);
         
         var actual = sut.translate("test");   
 

--- a/src/services/translations/translation.service.factory.ts
+++ b/src/services/translations/translation.service.factory.ts
@@ -32,8 +32,8 @@ export class WizdomTranslationServiceFactory {
         }, expireIn, refreshIn, refreshDelayIn)
         .then((translations) => {
             // Store a global variable
-            window["WizdomTranslations"] = translations;            
-            return new WizdomTranslationService(translations);            
+            window["WizdomTranslations"] = translations;                           
+            return new WizdomTranslationService(translations, this.context.wizdomdevelopermode);            
         });
     }
 }

--- a/src/services/translations/translation.service.ts
+++ b/src/services/translations/translation.service.ts
@@ -2,15 +2,15 @@ import { IWizdomTranslationService } from "./translation.interfaces";
 
 export class WizdomTranslationService implements IWizdomTranslationService {
     
-    constructor(private translations: object) {
+    constructor(private translations: object, private wizdomdevelopermode: boolean = false) {    
     }
 
     translate(key: string): string {
         if(this.translations)
-            return this.translations[key] || "[Translation missing: " + key + "]"; // fallback to the value, if no translation is defined for the spefified key
+            return this.translations[key] || (this.wizdomdevelopermode ? "[Translation missing: " + key + "]" : key); // fallback to the value, if no translation is defined for the spefified key
         else {
             console.warn("Wizdom translations not initialized");
-            return "[Translation error: " + key + "]";
+            return this.wizdomdevelopermode ? "[Translation error: " + key + "]" : key;
         }        
     }
 }

--- a/src/services/webapi/__tests__/webapi.service.spec.ts
+++ b/src/services/webapi/__tests__/webapi.service.spec.ts
@@ -26,7 +26,7 @@ describe("WizdomWebApiService", () => {
     });
 
     function setupWizdomWebApiService(): IWizdomWebApiService {
-        return new WizdomWebApiService("http://sharepointHostUrl.com", state, {Create(){return corsProxy}});
+        return new WizdomWebApiService("http://sharepointHostUrl.com", state, {GetOrCreate(){return corsProxy}});
     }
 
     it("should handle path releative api url", () => {  

--- a/src/services/webapi/webapi.service.factory.ts
+++ b/src/services/webapi/webapi.service.factory.ts
@@ -3,10 +3,8 @@ import { IWizdomWebApiService, IWizdomWebApiServiceState } from "./webapi.interf
 import { WizdomWebApiService } from "./webapi.service";
 import { WizdomCorsProxyServiceFactory } from "../corsproxy/corsproxy.service.factory";
 
-export class WizdomWebApiServiceFactory {        
-    private corsProxyFactory: WizdomCorsProxyServiceFactory;
-    constructor(private context: IWizdomContext, private spHostUrl: string, private userLoginName: string ) {        
-        this.corsProxyFactory = new WizdomCorsProxyServiceFactory(context, spHostUrl, userLoginName);
+export class WizdomWebApiServiceFactory {
+    constructor(private corsProxyFactory: WizdomCorsProxyServiceFactory, private spHostUrl: string) {                
     }
 
     Create() : IWizdomWebApiService {                


### PR DESCRIPTION
Fixing IE problem caused by using ECMAScript6 .endsWith.

Missing translation text only visible in development mode. Enabled by querystring wizdomdevelopermode.

Problems with insert of new webparts on a page containing other Wizdom webparts.
Problem was caused by missing assignment of a private corsproxy property.
Now assignment is set for all instances of webapi.service no matter if corsProxyReady was different from null. the null check caused the the assignment to only happen on pageload.