### PR TITLE
Register modern sitecollections in wizdom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "A list of core service to ease Wizdom development",
     "main": "dist/index.js",
     "types": "dist/main.d.ts",

--- a/src/services/corsproxy/corsproxy.service.factory.ts
+++ b/src/services/corsproxy/corsproxy.service.factory.ts
@@ -28,7 +28,7 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
             corsProxyIframe.style.display = "none";
             
             var appUrl = this.endsWith(this.context.appUrl, "/") ? this.context.appUrl : this.context.appUrl + "/";
-            corsProxyIframe.src = this.spHostUrl + "/_layouts/15/appredirect.aspx?client_id=" + this.context.clientId + "&redirect_uri=" + appUrl + "Base/WizdomCorsProxy.aspx?{StandardTokens}" + "%26userLoginName=" + encodeURIComponent(this.userLoginName);            
+            corsProxyIframe.src = this.spHostUrl + "/_layouts/15/appredirect.aspx?client_id=" + this.context.clientId + "&redirect_uri=" + appUrl + "Base/WizdomCorsProxy.aspx?{StandardTokens}" + "%26isModern=true%26userLoginName=" + encodeURIComponent(this.userLoginName);            
 
             document.body.appendChild(corsProxyIframe);
        


### PR DESCRIPTION
added isModern=true to corsproxy querystring, to make it possible for wizdom to differentiate classic and modern.