### PR TITLE
Translate should ignore null and empty strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.1.5",
+    "version": "1.1.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "description": "A list of core service to ease Wizdom development",
     "main": "dist/index.js",
     "types": "dist/main.d.ts",

--- a/src/services/translations/__tests__/translation.service.spec.ts
+++ b/src/services/translations/__tests__/translation.service.spec.ts
@@ -47,6 +47,16 @@ describe("WizdomTranslationService", () => {
         expect('[Translation missing: test]').toEqual(actual);
     });
 
+    it("should return key if it's null, even in developermode", () => {
+        var developermode = {} as IWizdomDeveloperMode;
+        var sut = new WizdomTranslationService({            
+        }, developermode);
+        
+        var actual = sut.translate(null);
+
+        expect(null).toEqual(actual);
+    });
+    
     it("should write error to console for missing translation if developermode configured for it", () => {
         var developermode = {
             errorMissingTranslations: true

--- a/src/services/translations/__tests__/translation.service.spec.ts
+++ b/src/services/translations/__tests__/translation.service.spec.ts
@@ -57,6 +57,16 @@ describe("WizdomTranslationService", () => {
         expect(null).toEqual(actual);
     });
     
+    it("should return key if it's empty string, even in developermode", () => {
+        var developermode = {} as IWizdomDeveloperMode;
+        var sut = new WizdomTranslationService({            
+        }, developermode);
+        
+        var actual = sut.translate("");
+
+        expect("").toEqual(actual);
+    });
+    
     it("should write error to console for missing translation if developermode configured for it", () => {
         var developermode = {
             errorMissingTranslations: true

--- a/src/services/translations/translation.service.ts
+++ b/src/services/translations/translation.service.ts
@@ -7,6 +7,9 @@ export class WizdomTranslationService implements IWizdomTranslationService {
     }
 
     translate(key: string): string {        
+        if(key == null || key == undefined || key == "")
+            return key;
+            
         if(this.translations){
             var translation = this.translations[key];            
             if(translation == null) { // Missing translation                

--- a/src/services/translations/translation.service.ts
+++ b/src/services/translations/translation.service.ts
@@ -7,13 +7,10 @@ export class WizdomTranslationService implements IWizdomTranslationService {
     }
 
     translate(key: string): string {        
-        if(key == null || key == undefined || key == "")
-            return key;
-
         if(this.translations){
             var translation = this.translations[key];            
             if(translation == null) { // Missing translation                
-                if(this.wizdomdevelopermode) {
+                if(this.wizdomdevelopermode && key) {
                     translation = "[Translation missing: " + key + "]";
                     if(this.wizdomdevelopermode.errorMissingTranslations) {
                         console.error(translation);

--- a/src/services/translations/translation.service.ts
+++ b/src/services/translations/translation.service.ts
@@ -9,7 +9,7 @@ export class WizdomTranslationService implements IWizdomTranslationService {
     translate(key: string): string {        
         if(key == null || key == undefined || key == "")
             return key;
-            
+
         if(this.translations){
             var translation = this.translations[key];            
             if(translation == null) { // Missing translation                


### PR DESCRIPTION
Translate returns "Missing translation" if trying to translate null og empty strings. But only in developermode.