### PR TITLE
Don't overwrite corsproxy instance if factory is reused

### DIFF
--- a/src/services/corsproxy/corsproxy.service.factory.ts
+++ b/src/services/corsproxy/corsproxy.service.factory.ts
@@ -12,7 +12,7 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
 
     GetOrCreate(recreate: boolean = false) : IWizdomCorsProxyService {
         var frame = this.getOrCreateIFrame(recreate);
-        this.frameService = new WizdomCorsProxyService(frame, this.getCorsProxySharedState());
+        this.frameService = this.frameService || new WizdomCorsProxyService(frame, this.getCorsProxySharedState());
         return this.frameService;
     }
 


### PR DESCRIPTION
If you tried to consume WizdomService.CorsProxyService and add a message handler it won't ever fire because the instance is overwritten when the WebApi handler is initialized and the factory is reused causing all the events to fire on the new instance and the old instance to just float around disconnected never getting any events