### PR TITLE
Add an error state for if the CorsProxy failed to init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "A list of core service to ease Wizdom development",
     "main": "dist/index.js",
     "types": "dist/main.d.ts",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,6 @@ export { WizdomSpfxServices } from "./services/wizdom.spfx.service";
 export { WizdomSpfxVueServices } from "./services/wizdom.spfx.vue.service";
 export { IWizdomCache, IWizdomLocalstorageCache, IWizdomPageViewCache } from "./services/caching/cache.interfaces";
 export { IWizdomContext } from "./services/context/context.interfaces";
-export { IWizdomWebApiService } from "./services/webapi/webapi.interfaces";
+export { IWizdomWebApiService, WebApiErrorType } from "./services/webapi/webapi.interfaces";
 export { IWizdomTranslationService } from "./services/translations/translation.interfaces";
 export { IHttpClient, IHttpClientResponse } from "./shared/httpclient.wrappers/http.interfaces";

--- a/src/services/corsproxy/corsproxy.interfaces.ts
+++ b/src/services/corsproxy/corsproxy.interfaces.ts
@@ -19,6 +19,7 @@ export interface IWizdomCorsProxySharedState {
     allWizdomRoles: Array<string>;
     rolesForCurrentUser: Array<string>;
     upgradeInProgress: boolean;
+    corsProxyFailed: boolean;
 }
 
 export type IFrameFunction = (recreate?: boolean) => IWizdomCorsProxyIframe;

--- a/src/services/corsproxy/corsproxy.service.factory.ts
+++ b/src/services/corsproxy/corsproxy.service.factory.ts
@@ -32,11 +32,11 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
             corsProxyIframe.onload = (ev: Event) => {
                 if(!window["WizdomCorsProxyState"].session) {
                     // If the frame finished loading but the state hasn't been set it's probably stuck on an error page
-                    window["WizdomCorsProxyState"].corsProxyFailed = true;
+                    this.corsproxyFailure();
                 }
             }
             corsProxyIframe.onerror = (ev: Event) => {
-                    window["WizdomCorsProxyState"].corsProxyFailed = true;
+                this.corsproxyFailure();
             }
 
             document.body.appendChild(corsProxyIframe);
@@ -44,6 +44,10 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
             window["WizdomCorsProxy"] = corsProxyIframe;
         }
         return window["WizdomCorsProxy"]["contentWindow"];
+    }
+    private corsproxyFailure() {
+        window["WizdomCorsProxyState"].corsProxyFailed = true;
+        this.frameService.HandleMessage({command: "WizdomCorsProxyFailed"});
     }
 
     private addEventListeners(){
@@ -66,12 +70,10 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
                 window["WizdomCorsProxyState"].rolesForCurrentUser = message.rolesForCurrentUser;
                 window["WizdomCorsProxyState"].upgradeInProgress = message.upgradeInProgress;
 
+                this.frameService.HandleMessage(message);
             } else if (message.command === "WizdomCorsProxyFailed") {
-                window["WizdomCorsProxyState"].corsProxyFailed = true;
-                alert("WizdomCorsProxyFailed");
+                this.corsproxyFailure();
             }
-            
-            this.frameService.HandleMessage(message);
 
         } catch (ex) {
             //console.log("wizdom postmessage error", e.data, ex);

--- a/src/services/corsproxy/corsproxy.service.factory.ts
+++ b/src/services/corsproxy/corsproxy.service.factory.ts
@@ -16,9 +16,9 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
         return this.frameService;
     }
 
-    private endsWith(str: string | any[], suffix: string | any[]) : boolean {
+    private endsWith(str: string | any[], suffix: any) : boolean {
         // using this endswith method to support IE
-        return str.indexOf((suffix as any), str.length - suffix.length) !== -1;
+        return str.indexOf(suffix, str.length - suffix.length) !== -1;
     }
 
     private getOrCreateIFrame(recreate: boolean = false) : IWizdomCorsProxyIframe {     

--- a/src/services/corsproxy/corsproxy.service.ts
+++ b/src/services/corsproxy/corsproxy.service.ts
@@ -15,10 +15,8 @@ export class WizdomCorsProxyService implements IWizdomCorsProxyService {
     HandleMessage(message: any): void {
         let handlers = this.handlers[message.command];
 
-        if (message.command === "WizdomCorsProxySuccess") {
-            console.timeEnd("corsproxy ready");                
-            
-            this.corsProxyState = message
+        if (message.command === "WizdomCorsProxySuccess") {            
+            this.corsProxyState = window["WizdomCorsProxyState"];
         }
 
         if(!handlers)

--- a/src/services/corsproxy/corsproxy.service.ts
+++ b/src/services/corsproxy/corsproxy.service.ts
@@ -19,6 +19,10 @@ export class WizdomCorsProxyService implements IWizdomCorsProxyService {
             this.corsProxyState = window["WizdomCorsProxyState"];
         }
 
+        if (message.command === "WizdomCorsProxyFailed") {            
+            this.corsProxyState = window["WizdomCorsProxyState"];
+        }
+
         if(!handlers)
             return;
 

--- a/src/services/webapi/__tests__/webapi.service.spec.ts
+++ b/src/services/webapi/__tests__/webapi.service.spec.ts
@@ -111,4 +111,44 @@ describe("WizdomWebApiService", () => {
         // expect error for request
         expect(webapiService.Get("api/test")).rejects.toEqual({errorType: WebApiErrorType.CorsProxyFailed , message: "Corsproxy failed initilisation"});
     })
+
+    it("Should fail queued requests if the corsproxy state chages to error", () => {
+        console.info = console.error = jest.fn(); // hide console spam from the SUT
+
+        var webapiService = setupWizdomWebApiService();
+         state.corsProxyReady = false;
+         state.corsProxyFailed = false;
+
+        // expect error for request when corsproxystate gets updated to failed
+        expect(webapiService.Get("api/test")).rejects.toEqual({errorType: WebApiErrorType.CorsProxyFailed , message: "Corsproxy failed initilisation"});
+
+        corsProxy.HandleMessage("WizdomCorsProxyFailed");
+    })
+
+    it("Should start failing requests if the corsproxy state chages to error", () => {
+        console.info = console.error = jest.fn(); // hide console spam from the SUT
+
+        var webapiService = setupWizdomWebApiService();
+         state.corsProxyReady = true;
+         state.corsProxyFailed = false;
+
+        // Expect success before corsproxy fails
+        expect(webapiService.Get("api/test")).rejects.toBeNull();
+
+        corsProxy.HandleMessage("WizdomCorsProxyFailed");
+
+        // expect error for request when corsproxystate has been updated to failed
+        expect(webapiService.Get("api/test")).rejects.toEqual({errorType: WebApiErrorType.CorsProxyFailed , message: "Corsproxy failed initilisation"});
+    })
+
+    it("Should complete queued requests when corsproxy succeedes initilization", () => {
+        console.info = console.error = jest.fn(); // hide console spam from the SUT
+
+        var webapiService = setupWizdomWebApiService();
+         state.corsProxyReady = true; // testing request when cors proxy is ready
+         state.corsProxyFailed = true; // testing request when cors proxy failed init
+
+        // expect error for request when state is dublicious claiming both success and faliure for the corsproxy state
+        expect(webapiService.Get("api/test")).rejects.toEqual({errorType: WebApiErrorType.CorsProxyFailed , message: "Corsproxy failed initilisation"});
+    })
 });

--- a/src/services/webapi/webapi.interfaces.ts
+++ b/src/services/webapi/webapi.interfaces.ts
@@ -14,3 +14,9 @@ export interface IWizdomWebApiServiceState {
     reCreateIframeTimer : NodeJS.Timer;
     requestRateLimitCounter : number;
 }
+
+export enum WebApiErrorType {
+    RequestFailed,
+    RateLimitExeeded,
+    CorsProxyFailed
+}

--- a/src/services/webapi/webapi.interfaces.ts
+++ b/src/services/webapi/webapi.interfaces.ts
@@ -13,6 +13,7 @@ export interface IWizdomWebApiServiceState {
     corsProxyReady?: boolean;
     reCreateIframeTimer : NodeJS.Timer;
     requestRateLimitCounter : number;
+    corsProxyFailed: boolean;
 }
 
 export enum WebApiErrorType {

--- a/src/services/webapi/webapi.service.factory.ts
+++ b/src/services/webapi/webapi.service.factory.ts
@@ -19,7 +19,8 @@ export class WizdomWebApiServiceFactory {
             reCreateIframeTimer : null,
             corsProxyReady : null,
             eventListenersAttached: false,
-            requestRateLimitCounter: 0
+            requestRateLimitCounter: 0,
+            corsProxyFailed: false,
         } as IWizdomWebApiServiceState; 
     }   
 }

--- a/src/services/webapi/webapi.service.factory.ts
+++ b/src/services/webapi/webapi.service.factory.ts
@@ -8,7 +8,7 @@ export class WizdomWebApiServiceFactory {
     }
 
     Create() : IWizdomWebApiService {                        
-        return window["WizdomWebApiService"] = new WizdomWebApiService(this.spHostUrl, this.getWebApiSharedState(), this.corsProxyFactory);
+        return window["WizdomWebApiService"] = window["WizdomWebApiService"] || new WizdomWebApiService(this.spHostUrl, this.getWebApiSharedState(), this.corsProxyFactory);
     }
 
     private getWebApiSharedState() {

--- a/src/services/wizdom.spfx.service.ts
+++ b/src/services/wizdom.spfx.service.ts
@@ -26,10 +26,7 @@ export class WizdomSpfxServices {
         this.spContext = spContext;
     }
 
-    public async InitAsync(options: any) {          
-        if(console.info != null)
-            console.info("initializing wizdom-intranet/services");
-        
+    public async InitAsync(options: any) {        
         try {
             // Check for development mode            
             var locationWrapper = new LocationWrapper();
@@ -69,8 +66,6 @@ export class WizdomSpfxServices {
             this.WizdomWebApiService = wizdomWebApiServiceFactory.Create();
             
             await Promise.all([translationServicePromise, configurationPromise]);
-
-            console.info("wizdom-intranet/services initialized");            
         } catch(ex) {
             if(console.exception != null)
                 console.exception("wizdom-intranet/services initializing error", ex);            


### PR DESCRIPTION
In some cases the CorsProxy can fail to init (Server down, clientSecret expired, permissions to sharepoint site).
If this happens there's no way for the clients to tell and their requests are just stuck in a queue forever which will never succeed or fail because the corsproxy ready event will never fire.

This change attempts to introduce a tracker of the corsproxy error state and reject promises if it fails to avoid stalled code which will never resolve/fail