### PR TITLE
sync users preferred SharePoint language to Wizdom

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,6 @@ Set-PnPPropertyBagValue -Key "wizdom.properties" -Value '{"appUrl":"https://url.
 $site.Update()
 $site.Context.ExecuteQuery()
 ```
+
+# User language
+Once every 12 hours wizdom-service check if the current users preferred SharePoint UI language match the one stored in Wizdom. If they don't match it will automatically be updated in Wizdom.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1755,7 +1755,7 @@
             "dependencies": {
                 "es6-promise": {
                     "version": "4.1.1",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/es6-promise/-/es6-promise-4.1.1.tgz",
+                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
                     "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
                 },
                 "tslib": {
@@ -1765,7 +1765,7 @@
                 },
                 "whatwg-fetch": {
                     "version": "2.0.3",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
                     "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
                 }
             }
@@ -8305,7 +8305,7 @@
             "dependencies": {
                 "camelcase": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/camelcase/-/camelcase-4.1.0.tgz",
                     "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                     "dev": true
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.4.12",
+    "version": "1.4.13",
     "description": "A list of core service to ease Wizdom development",
     "main": "dist/index.js",
     "types": "dist/main.d.ts",

--- a/src/__tests__/wizdom.language.update.spec.ts
+++ b/src/__tests__/wizdom.language.update.spec.ts
@@ -1,0 +1,73 @@
+import { IWizdomLocalstorageCache, IWizdomCache } from "../services/caching/cache.interfaces";
+import { WizdomLanguageUpdate } from "../services/wizdom.language.update";
+import { IHttpClientResponse, IHttpClient } from "../shared/httpclient.wrappers/http.interfaces";
+import { IWizdomWebApiService } from "../services/webapi/webapi.interfaces";
+
+describe("WizdomLanguageUpdate", () => {
+    var fakeSpUrl = "http://sharepointHostUrl.com";
+
+    // Mock Caching    
+    var mockCache = jest.fn(() => ({
+        Localstorage: jest.fn(() => ({            
+            ExecuteCached: jest.fn((key: string, func: Function) => {
+                return func();
+            })
+        }) as IWizdomLocalstorageCache)(),
+        Timestamps: {
+            Get: (key) => Promise.resolve(42)
+        }
+    }) as IWizdomCache)();
+
+    // Fake SpHttpClient
+    function getFakeSpHttpClient(mockData) {
+        var httpClientGetMock = function(url: string) {
+            return Promise.resolve({
+                ok: true,
+                text: jest.fn(),
+                json: ()=> {                    
+                    if(url.indexOf("_api/SP.UserProfiles.PeopleManager/GetMyProperties")>0) // request for tenant properties
+                        return Promise.resolve(mockData);                
+                    return null; // ignore all other requests
+                },
+            } as IHttpClientResponse);
+        };
+        const HttpClientMockImplementation = jest.fn<IHttpClient, any>(() => ({
+            get: httpClientGetMock            
+        }));
+        return new HttpClientMockImplementation();
+    }
+
+    // Fake WebApiService
+    var mockWebApiService;
+    beforeEach(() => {
+        mockWebApiService = {
+            Get: jest.fn(),
+            Delete: jest.fn(),                
+            Post: jest.fn(),
+            Put: jest.fn()
+        } as IWizdomWebApiService;
+    });
+
+  var oldWizdomLanguage = "en-us";
+
+  it("should update language if wizdom language and preferred language are different", async () => {    
+    var wizdomLanguageUpdate = new WizdomLanguageUpdate(getFakeSpHttpClient({
+        UserProfileProperties: [{"Key":"SPS-MUILanguages","Value":"da-dk,en-us"}]
+    }), mockWebApiService, mockCache);
+
+    await wizdomLanguageUpdate.UpdateIfNeededAsync(fakeSpUrl, oldWizdomLanguage);
+    
+    expect(mockWebApiService.Put).toHaveBeenCalledTimes(1);
+    expect(mockWebApiService.Put).toHaveBeenCalledWith("api/wizdom/365/principals/me/language", "da-dk");    
+  });  
+
+  it("should update language if wizdom language and preferred language are different", async () => {    
+    var wizdomLanguageUpdate = new WizdomLanguageUpdate(getFakeSpHttpClient({
+        UserProfileProperties: [{"Key":"SPS-MUILanguages","Value":"en-us,da-dk"}]
+    }), mockWebApiService, mockCache);
+
+    await wizdomLanguageUpdate.UpdateIfNeededAsync(fakeSpUrl, oldWizdomLanguage);
+    
+    expect(mockWebApiService.Put).toHaveBeenCalledTimes(0);    
+  });  
+});

--- a/src/services/caching/cache.ts
+++ b/src/services/caching/cache.ts
@@ -16,7 +16,7 @@ export class WizdomCache implements IWizdomCache {
     public TimestampsResolver: IWizdomTimestampsResolver;
   
     constructor(wizdomDeveloperMode: IWizdomDeveloperMode, locationWrapper: ILocationWrapper, spHttpClient?: IHttpClient, absoluteUrl?: string) {
-        var forceNoCache = (locationWrapper && locationWrapper.GetQueryString("nocache") == "true") || (wizdomDeveloperMode && wizdomDeveloperMode.nocache)
+        var forceNoCache = (locationWrapper && locationWrapper.GetQueryString("nocache") == "true") || (wizdomDeveloperMode && wizdomDeveloperMode.nocache);
         this.PageView = new WizdomPageViewCache(this, forceNoCache);
         var timestamps  = new WizdomTimestamps(this, forceNoCache, spHttpClient, absoluteUrl);
         this.Localstorage = new WizdomLocalStorageCache(this.PageView, forceNoCache, timestamps);

--- a/src/services/corsproxy/corsproxy.interfaces.ts
+++ b/src/services/corsproxy/corsproxy.interfaces.ts
@@ -17,8 +17,9 @@ export interface IWizdomCorsProxySharedState {
     session: string;
     msLeftOnToken: Number;
     allWizdomRoles: Array<string>;
-    rolesForCurrentUser: Array<string>;
+    rolesForCurrentUser: Array<string>;    
     upgradeInProgress: boolean;
+    currentUserLanguage: string;
     corsProxyFailed: boolean;
 }
 

--- a/src/services/corsproxy/corsproxy.service.factory.ts
+++ b/src/services/corsproxy/corsproxy.service.factory.ts
@@ -90,6 +90,7 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
                 window["WizdomCorsProxyState"].allWizdomRoles = message.allWizdomRoles;
                 window["WizdomCorsProxyState"].rolesForCurrentUser = message.rolesForCurrentUser;
                 window["WizdomCorsProxyState"].upgradeInProgress = message.upgradeInProgress;
+                window["WizdomCorsProxyState"].currentUserLanguage = message.currentUserLanguage;
                 window["WizdomCorsProxyState"].corsProxyFailed = false;
 
             } else if (message.command === "WizdomCorsProxyFailed") {
@@ -111,6 +112,7 @@ export class WizdomCorsProxyServiceFactory implements IWizdomCorsProxyServiceFac
             allWizdomRoles: [], 
             rolesForCurrentUser: [], 
             upgradeInProgress: false,
+            currentUserLanguage: "",
             corsProxyFailed: false
         } as IWizdomCorsProxySharedState; 
     }

--- a/src/services/wizdom.language.update.ts
+++ b/src/services/wizdom.language.update.ts
@@ -9,23 +9,20 @@ export class WizdomLanguageUpdate {
     public async UpdateIfNeededAsync(webAbsoluteUrl: string, currentUserLanguage: string) { 
         await this.cache.Localstorage.ExecuteCached("WizdomUserLanguage", async () => {            
             var apiUrl ="/_api/SP.UserProfiles.PeopleManager/GetMyProperties";
-            return this.spHttpClient.get(webAbsoluteUrl + apiUrl)
-            .then((response): Promise<string> => {          
-                return response.json();
-            }).then((result: any) => {
-                var preferredLanguage:string = "";
-                (result.UserProfileProperties).forEach(async property => {
-                    if(property.Key == "SPS-MUILanguages" && property.Value)
-                    {
-                        preferredLanguage = property.Value.split(',')[0];                        
-                        if(preferredLanguage.toLowerCase() !== currentUserLanguage.toLowerCase()){
-                            this.wizdomWebApiService.Put("api/wizdom/365/principals/me/language", preferredLanguage);                        
-                        }
-                        return; // break loop
+            var response = await this.spHttpClient.get(webAbsoluteUrl + apiUrl);            
+            var result:any = await response.json();
+            var preferredLanguage:string = "";
+            (result.UserProfileProperties).forEach(async property => {
+                if(property.Key == "SPS-MUILanguages" && property.Value)
+                {
+                    preferredLanguage = property.Value.split(',')[0];                        
+                    if(preferredLanguage.toLowerCase() !== currentUserLanguage.toLowerCase()){
+                        this.wizdomWebApiService.Put("api/wizdom/365/principals/me/language", preferredLanguage);                        
                     }
-                });
-                return preferredLanguage;                
+                    return; // break loop
+                }
             });
+            return preferredLanguage;                
         }, 
         1000 * 60 * 60 * 24 * 30, // expire in 30 days
         1000 * 60 * 60 * 12, // refresh every 12 hour

--- a/src/services/wizdom.language.update.ts
+++ b/src/services/wizdom.language.update.ts
@@ -1,0 +1,34 @@
+import { IWizdomWebApiService } from "./webapi/webapi.interfaces";
+import { IWizdomCache } from "./caching/cache.interfaces";
+import { IHttpClient } from "../shared/httpclient.wrappers/http.interfaces";
+
+export class WizdomLanguageUpdate {
+    
+    constructor(private spHttpClient: IHttpClient, private wizdomWebApiService: IWizdomWebApiService, private cache: IWizdomCache) {    }
+
+    public async UpdateIfNeededAsync(webAbsoluteUrl: string, currentUserLanguage: string) { 
+        await this.cache.Localstorage.ExecuteCached("WizdomUserLanguage", async () => {            
+            var apiUrl ="/_api/SP.UserProfiles.PeopleManager/GetMyProperties";
+            return this.spHttpClient.get(webAbsoluteUrl + apiUrl)
+            .then((response): Promise<string> => {          
+                return response.json();
+            }).then((result: any) => {
+                var preferredLanguage:string = "";
+                (result.UserProfileProperties).forEach(async property => {
+                    if(property.Key == "SPS-MUILanguages" && property.Value)
+                    {
+                        preferredLanguage = property.Value.split(',')[0];                        
+                        if(preferredLanguage.toLowerCase() !== currentUserLanguage.toLowerCase()){
+                            this.wizdomWebApiService.Put("api/wizdom/365/principals/me/language", preferredLanguage);                        
+                        }
+                        return; // break loop
+                    }
+                });
+                return preferredLanguage;                
+            });
+        }, 
+        1000 * 60 * 60 * 24 * 30, // expire in 30 days
+        1000 * 60 * 60 * 12, // refresh every 12 hour
+        1000 * 5); // delayed refresh in 5 seconds        
+    }
+}


### PR DESCRIPTION
Just as in classic we compare the currentusers preferred language clientside and invoke an update in Wizdom if needed.