### PR TITLE
Support Wizdom SaaS

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  presets: ['@babel/preset-env'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,12 @@ module.exports = {
     transform: {
       '^.+\\.vue$': 'vue-jest',
       '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
-      '^.+\\.tsx?$': 'ts-jest'
+      '^.+\\.tsx?$': 'ts-jest',
+      "^.+\\.js?$": "babel-jest"
     },
+    transformIgnorePatterns: [
+      "node_modules/(?!@microsoft/sp-http|@microsoft/sp-core-library|@microsoft/sp-diagnostics)"
+    ],
     moduleNameMapper: {
       '^@/(.*)$': '<rootDir>/src/$1'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.4.12",
+    "version": "1.4.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -808,9 +808,9 @@
             }
         },
         "@microsoft/decorators": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.8.2.tgz",
-            "integrity": "sha512-1tWDtxh6Mks5JjqI2yRPBD3ZaOT1DhDh6+Z/Lj1LWA+OU4CnIkl2P3uGkiKhchXlgHBeKUidFGRVrv0parfTRQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.10.0.tgz",
+            "integrity": "sha512-4D4DaG01XMNM253yFmLvtucPfdzj3UABpQ/4/02/Pnvt9fXGgg/TCxSApto4u8Vxka64uO7LCxMG5Fd1qv4b8Q==",
             "requires": {
                 "tslib": "~1.9.3"
             },
@@ -823,9 +823,17 @@
             }
         },
         "@microsoft/load-themed-styles": {
-            "version": "1.7.53",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/@microsoft/load-themed-styles/-/load-themed-styles-1.7.53.tgz",
-            "integrity": "sha1-J7KoW8wJdoyOwrZS/9mIBCeah8U="
+            "version": "1.10.41",
+            "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.41.tgz",
+            "integrity": "sha512-oA16YDh9us9QVjlvCBdg50blzvChuD2zLM0awnuHC0BivV2P2Og2sD9qh12znH8w82yDyCrqj9Qiie7xI9qJ/g=="
+        },
+        "@microsoft/loader-raw-script": {
+            "version": "1.2.182",
+            "resolved": "https://registry.npmjs.org/@microsoft/loader-raw-script/-/loader-raw-script-1.2.182.tgz",
+            "integrity": "sha512-Uin++eH+eML7omSXTIrO4LBfphzCgC+ZyaboP9IL2S2S25x/sfNfdMcMMXghzZ00K231u1ygTs2Ta7lhlY7G5g==",
+            "requires": {
+                "loader-utils": "~1.1.0"
+            }
         },
         "@microsoft/microsoft-graph-client": {
             "version": "1.1.0",
@@ -837,16 +845,16 @@
             }
         },
         "@microsoft/office-ui-fabric-react-bundle": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.8.2.tgz",
-            "integrity": "sha512-KQ07naCdJXW6nquDDEP/ydb8SHoFj1Kcsldj5qREcdJIZfUkrlxXRpFlgJoVKdPF3sYomDSssTCQf8pmy0uicA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.10.0.tgz",
+            "integrity": "sha512-T2Rvf8bdRQt7PHH9vLfc7lkkEzfXIAwqTPqIW7IkwQwORJ8oeYJdEO92SqQOkGtJdxLtXt6dQm0f9G8YH5huDw==",
             "requires": {
-                "@types/react": "16.4.2",
+                "@types/react": "16.8.8",
                 "@types/webpack-env": "1.13.1",
-                "@uifabric/icons": "6.4.0",
-                "office-ui-fabric-react": "6.143.0",
-                "react": "16.7.0",
-                "react-dom": "16.7.0",
+                "@uifabric/icons": "7.3.0",
+                "office-ui-fabric-react": "7.59.0",
+                "react": "16.8.5",
+                "react-dom": "16.8.5",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
@@ -858,162 +866,172 @@
             }
         },
         "@microsoft/sp-application-base": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-application-base/-/sp-application-base-1.8.2.tgz",
-            "integrity": "sha512-kpsp4Hby6nIPVR9QnHWZqF5QMV7lsYHaIkgg/NDLv4BDaIvvR9YnPAPeXas0Z6I6ovIwzo/o5WbTelTac/K4rw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-application-base/-/sp-application-base-1.10.0.tgz",
+            "integrity": "sha512-KMwWqAFa1Wx1ZhRv2CWRYSfz8QdwsIGWWry9cq06WlFFpXbEyCMGPB/XOKrxWnWgK+TO/l04kiyxnE1aGAclkg==",
             "requires": {
-                "@microsoft/decorators": "1.8.2",
-                "@microsoft/sp-component-base": "1.8.2",
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-extension-base": "1.8.2",
-                "@microsoft/sp-http": "1.8.2",
-                "@microsoft/sp-loader": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
-                "@microsoft/sp-module-interfaces": "1.8.2",
-                "@microsoft/sp-odata-types": "1.8.2",
-                "@microsoft/sp-page-context": "1.8.2",
-                "@types/es6-promise": "0.0.33",
-                "@types/webpack-env": "1.13.1",
+                "@microsoft/decorators": "1.10.0",
+                "@microsoft/sp-component-base": "1.10.0",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-extension-base": "1.10.0",
+                "@microsoft/sp-http": "1.10.0",
+                "@microsoft/sp-loader": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
+                "@microsoft/sp-odata-types": "1.10.0",
+                "@microsoft/sp-page-context": "1.10.0",
+                "@microsoft/sp-search-extensibility": "1.10.0",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
                 "@microsoft/decorators": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.8.2.tgz",
-                    "integrity": "sha512-1tWDtxh6Mks5JjqI2yRPBD3ZaOT1DhDh6+Z/Lj1LWA+OU4CnIkl2P3uGkiKhchXlgHBeKUidFGRVrv0parfTRQ==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.10.0.tgz",
+                    "integrity": "sha512-4D4DaG01XMNM253yFmLvtucPfdzj3UABpQ/4/02/Pnvt9fXGgg/TCxSApto4u8Vxka64uO7LCxMG5Fd1qv4b8Q==",
                     "requires": {
                         "tslib": "~1.9.3"
                     }
                 },
+                "@microsoft/load-themed-styles": {
+                    "version": "1.10.41",
+                    "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.41.tgz",
+                    "integrity": "sha512-oA16YDh9us9QVjlvCBdg50blzvChuD2zLM0awnuHC0BivV2P2Og2sD9qh12znH8w82yDyCrqj9Qiie7xI9qJ/g=="
+                },
                 "@microsoft/office-ui-fabric-react-bundle": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.8.2.tgz",
-                    "integrity": "sha512-KQ07naCdJXW6nquDDEP/ydb8SHoFj1Kcsldj5qREcdJIZfUkrlxXRpFlgJoVKdPF3sYomDSssTCQf8pmy0uicA==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.10.0.tgz",
+                    "integrity": "sha512-T2Rvf8bdRQt7PHH9vLfc7lkkEzfXIAwqTPqIW7IkwQwORJ8oeYJdEO92SqQOkGtJdxLtXt6dQm0f9G8YH5huDw==",
                     "requires": {
-                        "@types/react": "16.4.2",
+                        "@types/react": "16.8.8",
                         "@types/webpack-env": "1.13.1",
-                        "@uifabric/icons": "6.4.0",
-                        "office-ui-fabric-react": "6.143.0",
-                        "react": "16.7.0",
-                        "react-dom": "16.7.0",
+                        "@uifabric/icons": "7.3.0",
+                        "office-ui-fabric-react": "7.59.0",
+                        "react": "16.8.5",
+                        "react-dom": "16.8.5",
                         "tslib": "~1.9.3"
                     }
                 },
                 "@microsoft/sp-component-base": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.8.2.tgz",
-                    "integrity": "sha512-8v7YOYgolyMuBzFrdMvLIalXTpBt4REvy//csoAsDudshjKI0trBDLcjaryjnshz33bzcLvaZArsfRXl3C4pEw==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.10.0.tgz",
+                    "integrity": "sha512-9XEkYGJfVaGGqcBZ87maH8h76ohQEIqRr0wOhvVQ4ME45SK64zoCX35aOazNU28TYbqphCMSLKYS/JQSyRjuiA==",
                     "requires": {
-                        "@microsoft/decorators": "1.8.2",
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-dynamic-data": "1.8.2",
-                        "@microsoft/sp-http": "1.8.2",
-                        "@microsoft/sp-loader": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-module-interfaces": "1.8.2",
-                        "@microsoft/sp-page-context": "1.8.2",
+                        "@microsoft/decorators": "1.10.0",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-dynamic-data": "1.10.0",
+                        "@microsoft/sp-http": "1.10.0",
+                        "@microsoft/sp-loader": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@microsoft/sp-page-context": "1.10.0",
                         "@types/es6-promise": "0.0.33",
                         "@types/webpack-env": "1.13.1"
                     }
                 },
                 "@microsoft/sp-core-library": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.8.2.tgz",
-                    "integrity": "sha512-RW06oLu7sdMjq6vNtTFhvsQ7R7Ix5oJZqefC2J7p23yBWNNatmcwaBqM01SVdAsHd1coKwq3eU/0YMhzuaxKQw==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.10.0.tgz",
+                    "integrity": "sha512-np8GKJ90GJw5Qc1ZttYXYwwypupNxhcnWJ3Xm3tTgvDvkFyeTU0tOjUGKp9cPOBsUADxMIRtruUEBsi8Ip73yQ==",
                     "requires": {
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-module-interfaces": "1.8.2",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
                         "@types/es6-promise": "0.0.33",
                         "@types/webpack-env": "1.13.1"
                     }
                 },
                 "@microsoft/sp-diagnostics": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.8.2.tgz",
-                    "integrity": "sha512-l7qRUQduWG9waFgIP08E922PY+ea7xa2HZiEUDA6pdSOXbci2R9uo3fgL2Un5e63ZPKa5E1/0jtm1+xtgQkutA==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.10.0.tgz",
+                    "integrity": "sha512-LDQBjEW+S8aGumcfTdPSxC1Vosq5jzmXnYj+xvgfKqCnbo+VV8rTCyUYNENGb7+V2qyB9Q/o9ddm41aUxSg+Tg==",
                     "requires": {
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2"
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0"
                     }
                 },
                 "@microsoft/sp-dynamic-data": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.8.2.tgz",
-                    "integrity": "sha512-oC4220aH1ooU+VU9ADgnEeZ6YmWZfqvFaFG5vd2EL3jzTYiIxGLvBZOfDGKnsgmaDoWC7lXIYncoG0Os3rh/6w==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.10.0.tgz",
+                    "integrity": "sha512-XXTnLWeEcEDq3dcG+e0UV2HlmW/NUuuSaqU3O05xNUbx0VQJU5abuO34DGxwFyoKRp9NhG9iem1FExQiyijWDQ==",
                     "requires": {
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@types/es6-promise": "0.0.33",
                         "@types/webpack-env": "1.13.1",
                         "tslib": "~1.9.3"
                     }
                 },
                 "@microsoft/sp-extension-base": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.8.2.tgz",
-                    "integrity": "sha512-kBoV6fIhM25ORZM5iA+HTiFX5jm5oLaue8nHnyYCFyATy14wSSG9i47OF3OxMsATY4qMaQ8W2YQIaWu3Sdnhvw==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.10.0.tgz",
+                    "integrity": "sha512-jvWjJhy/5DkKhU6NzHyg/uDobXg8lVR6O/i9blZ14TuxFOyF+MHeoGNaK2f8wrxGUohiedNrjAMnKTVnsLahHA==",
                     "requires": {
-                        "@microsoft/decorators": "1.8.2",
-                        "@microsoft/sp-component-base": "1.8.2",
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-http": "1.8.2",
-                        "@microsoft/sp-loader": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-module-interfaces": "1.8.2",
-                        "@microsoft/sp-page-context": "1.8.2",
+                        "@microsoft/decorators": "1.10.0",
+                        "@microsoft/sp-component-base": "1.10.0",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-http": "1.10.0",
+                        "@microsoft/sp-loader": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@microsoft/sp-page-context": "1.10.0",
                         "@types/es6-promise": "0.0.33",
                         "@types/webpack-env": "1.13.1"
                     }
                 },
                 "@microsoft/sp-http": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.8.2.tgz",
-                    "integrity": "sha512-lTVQ6oI1yjc4M0yeyQHrivy+6SNp1q4xUQ3skBWY25b55zPIJHH3m/nOvHy2q44b9eWurdjq7bS1T19lrf7+LQ==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.10.0.tgz",
+                    "integrity": "sha512-8H76ORi4NV3ByNvvvENgucH7xdezdFGlJdxlOYIkzhyWgYsm/IEzFCNNBOChQk8kmlP/PqF146Ft6PIYgrZ6og==",
                     "requires": {
                         "@microsoft/microsoft-graph-client": "~1.1.0",
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
                         "@types/adal-angular": "1.0.1",
                         "adal-angular": "1.0.16",
+                        "msal": "1.1.3",
                         "tslib": "~1.9.3"
                     }
                 },
                 "@microsoft/sp-loader": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.8.2.tgz",
-                    "integrity": "sha512-Q1LKFV8jOqWV6451dpDFwyaMK2Hw4X+tcnX5hFqltL1O1r/rD2P7PJkLi8lpL8sqWJ9JhTDDY8+pWD1YYC6W6A==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.10.0.tgz",
+                    "integrity": "sha512-fJs0kXHK/QiF5JkkI64bZbdC0nGYEanua5MjawZxQO2c8KY9uVK/h2cJXIN9OnAL5lbn5gJD5aE4jQe2z4BBgQ==",
                     "requires": {
-                        "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-dynamic-data": "1.8.2",
-                        "@microsoft/sp-http": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-module-interfaces": "1.8.2",
-                        "@microsoft/sp-odata-types": "1.8.2",
-                        "@microsoft/sp-page-context": "1.8.2",
-                        "@microsoft/sp-polyfills": "1.8.2",
+                        "@microsoft/loader-raw-script": "1.2.182",
+                        "@microsoft/office-ui-fabric-react-bundle": "1.10.0",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-dynamic-data": "1.10.0",
+                        "@microsoft/sp-http": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@microsoft/sp-odata-types": "1.10.0",
+                        "@microsoft/sp-page-context": "1.10.0",
+                        "@microsoft/sp-polyfills": "1.10.0",
                         "@types/es6-promise": "0.0.33",
-                        "@types/node": "8.5.8",
-                        "@types/react": "16.4.2",
-                        "@types/react-dom": "16.0.5",
+                        "@types/react": "16.8.8",
+                        "@types/react-dom": "16.8.3",
                         "@types/requirejs": "2.1.29",
                         "@types/webpack-env": "1.13.1",
-                        "@uifabric/utilities": "6.29.4",
-                        "office-ui-fabric-react": "6.143.0",
-                        "react": "16.7.0",
-                        "react-dom": "16.7.0",
+                        "@uifabric/utilities": "7.5.0",
+                        "exports-loader": "~0.6.4",
+                        "office-ui-fabric-react": "7.59.0",
+                        "raw-loader": "~0.5.1",
+                        "react": "16.8.5",
+                        "react-dom": "16.8.5",
                         "requirejs": "2.1.20",
                         "tslib": "~1.9.3"
                     }
                 },
                 "@microsoft/sp-lodash-subset": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.8.2.tgz",
-                    "integrity": "sha512-PTJuBAqqgxJ6xo8OQWS4sTPOyzgXzPyT60BTHyZJd8ozDoeo3lrTssmXgOaAygMUE+VglyoH7YRNAv+fg/tOgQ==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.10.0.tgz",
+                    "integrity": "sha512-DxBSb+3nN0XWmo3swC2nva4VKaCNvrzNXSnr7kfqzdXga9phi8MWBf1HTBophI8PnkxlkV1fEWgs0c7pEuuYFw==",
                     "requires": {
                         "@types/lodash": "4.14.117",
                         "@types/webpack-env": "1.13.1",
@@ -1021,42 +1039,42 @@
                     }
                 },
                 "@microsoft/sp-module-interfaces": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.8.2.tgz",
-                    "integrity": "sha512-vuwmEHZ1dP9Q5/irqpTJynkHmyxP2vfn05Bdehzd/ktlvf4CtUjgVIRXuOCPufGe5fvr96IMKLlhOzifS5sUBw==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.10.0.tgz",
+                    "integrity": "sha512-OGmqAmE8TbJF/1WWi2VwKtlxenUL/vu1d5h4ev87Gd3xvusTMkglVlMhNzePMYVYdzdszUVgTTvBeDV/c8tVEg==",
                     "requires": {
-                        "@types/node": "8.5.8",
+                        "@types/node": "8.10.54",
                         "@types/z-schema": "3.16.31",
                         "z-schema": "~3.18.3"
                     }
                 },
                 "@microsoft/sp-odata-types": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.8.2.tgz",
-                    "integrity": "sha512-reRLI23NHfUwJAcQmTGl3z80ncqRlW6YSs8OoZFkIEsYsnuv7P+xwJnhH+4im8ywJ+3ESEOZj6ZtdrvUM9PcmA==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.10.0.tgz",
+                    "integrity": "sha512-O3kGcABicM5mgG9jUzqTU6tXZZPIGRZcM6uGry+v8M31r+ktptXyOOd7DkReNzFFxDJuXnqTAjusHMVx1N5+2A==",
                     "requires": {
                         "tslib": "~1.9.3"
                     }
                 },
                 "@microsoft/sp-page-context": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.8.2.tgz",
-                    "integrity": "sha512-TkVV/h5XEJUfGH/80y0YPD3jWEli8V3Z+Xsnub0ZjC5lU492J1JLFDeNMqIlG25vhIeL+V+Le9hxU9cTNW4hsA==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.10.0.tgz",
+                    "integrity": "sha512-EWqbL299gqlVUtETsogQDf3OacusLC0YoM0Yu4/dxiCbTJCE6FjaR4oDYYUa30HbqAe/Tmko3c5Buah7TkaB/g==",
                     "requires": {
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-dynamic-data": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-odata-types": "1.8.2",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-dynamic-data": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-odata-types": "1.10.0",
                         "@types/es6-promise": "0.0.33",
                         "@types/webpack-env": "1.13.1",
                         "tslib": "~1.9.3"
                     }
                 },
                 "@microsoft/sp-polyfills": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.8.2.tgz",
-                    "integrity": "sha512-0Zl7ipeFws2PJYbtVQ0UMWzBExZuH5qQZuzf25KXmYsQd8tgMNBI3C1OCnTqbTYVx8LhdJtlf5y5D1mYLV4Raw==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.10.0.tgz",
+                    "integrity": "sha512-oboAg9zAH/P86CgG+8RA8wpL9aLJtYtchcVjnQxTYp3wMvHtNWEysHWBHtjIapTLEKXbPwNQ8Apnsy2TstNcZg==",
                     "requires": {
                         "@types/webpack-env": "1.13.1",
                         "es6-collections": "0.5.6",
@@ -1066,79 +1084,136 @@
                         "whatwg-url": "4.7.1"
                     }
                 },
-                "@types/lodash": {
-                    "version": "4.14.117",
-                    "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-                    "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw=="
+                "@types/node": {
+                    "version": "8.10.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+                    "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg=="
                 },
                 "@types/react": {
-                    "version": "16.4.2",
-                    "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.2.tgz",
-                    "integrity": "sha512-oVcVteCDNiVc/fkDjowRfAZQDEOR76j3CJ3FvwXNvfV6zJguhghy1lMgpAzYox+9AZsWch+JPV6Imml3wvIUeg==",
+                    "version": "16.8.8",
+                    "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.8.tgz",
+                    "integrity": "sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==",
                     "requires": {
+                        "@types/prop-types": "*",
                         "csstype": "^2.2.0"
                     }
                 },
                 "@types/react-dom": {
-                    "version": "16.0.5",
-                    "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.5.tgz",
-                    "integrity": "sha512-ony2hEYlGXCLWNAWWgbsHR7qVvDbeMRFc5b43+7dhj3n+zXzxz81HV9Yjpc3JD8vLCiwYoSLqFCI6bD0+0zG2Q==",
+                    "version": "16.8.3",
+                    "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.3.tgz",
+                    "integrity": "sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==",
                     "requires": {
-                        "@types/node": "*",
                         "@types/react": "*"
                     }
                 },
-                "@uifabric/icons": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.4.0.tgz",
-                    "integrity": "sha512-pbKu3OnWaRIeDqMFhicDrrcqicxNqoHpJpknZR9N2xxoPnYMnt2ZOhBNnAxoVVcxHlWkFNg0rvFrOAQGn+S5/Q==",
+                "@uifabric/foundation": {
+                    "version": "7.5.23",
+                    "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.5.23.tgz",
+                    "integrity": "sha512-FIzJorSPmazXgiLauRufFnlhKd3W9X0x7iq5EbPHg8zwem6S87qzHn4IuXxBde9KE3LvAtflzlak+VNdXUsPdg==",
                     "requires": {
-                        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                        "@uifabric/styling": ">=6.41.0 <7.0.0",
+                        "@uifabric/merge-styles": "^7.8.10",
+                        "@uifabric/set-version": "^7.0.9",
+                        "@uifabric/styling": "^7.11.0",
+                        "@uifabric/utilities": "^7.15.3",
+                        "tslib": "^1.10.0"
+                    },
+                    "dependencies": {
+                        "@uifabric/utilities": {
+                            "version": "7.15.3",
+                            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.3.tgz",
+                            "integrity": "sha512-VuVv5SHOaPrpT+fONDgnpd/871TXXfQWxCgn+fETVvhsHKskVK0MhnTbi3f6MhHJZQl2SyYCUKbnOCIWguu4eQ==",
+                            "requires": {
+                                "@uifabric/merge-styles": "^7.8.10",
+                                "@uifabric/set-version": "^7.0.9",
+                                "prop-types": "^15.7.2",
+                                "tslib": "^1.10.0"
+                            }
+                        },
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                        }
+                    }
+                },
+                "@uifabric/icons": {
+                    "version": "7.3.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.0.tgz",
+                    "integrity": "sha512-wbcR8fJce20sPjsK2bbTC/cAZfAOFuE4dd4LHw194+8H+/dqotsowrQVp5Lu8aaHGQk+fXoiZmUy30WA9cAG4Q==",
+                    "requires": {
+                        "@uifabric/set-version": "^7.0.2",
+                        "@uifabric/styling": "^7.7.1",
                         "tslib": "^1.7.1"
                     }
                 },
                 "@uifabric/merge-styles": {
-                    "version": "6.17.4",
-                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.17.4.tgz",
-                    "integrity": "sha512-IYg+LiyetyqSadHTHYYUfpYKWdlKIF5LTmumMX2Mp0HtgAc51KOf2xx2XX6M35jERIGyBSvQruOXjvJXVGsXSg==",
+                    "version": "7.8.10",
+                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.8.10.tgz",
+                    "integrity": "sha512-VQ2GE6YVL9IGAgd7ZGpDMpwjNy4Ls4Wlb+ijugDRCK/DKgl2mX2iSUGV+fsWgiHAt8O1LQP5mvggtMPNOroSTw==",
                     "requires": {
-                        "@uifabric/set-version": "^1.1.3",
-                        "tslib": "^1.7.1"
+                        "@uifabric/set-version": "^7.0.9",
+                        "tslib": "^1.10.0"
+                    },
+                    "dependencies": {
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                        }
+                    }
+                },
+                "@uifabric/set-version": {
+                    "version": "7.0.9",
+                    "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.9.tgz",
+                    "integrity": "sha512-YJL6WLBlFKDJcLSw1ihqW5PTFi2XMoluEvwGd2qtzp2IVbHvdbk7uIdWuTALo3dFNNqWPN8shSNUdHVATE/1jQ==",
+                    "requires": {
+                        "tslib": "^1.10.0"
+                    },
+                    "dependencies": {
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                        }
                     }
                 },
                 "@uifabric/styling": {
-                    "version": "6.47.6",
-                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.47.6.tgz",
-                    "integrity": "sha512-nTsuwEbPTUofPFX3/RZ8FprRUTI02GsRffdNIxannHuVBntHAbKB0CrvQ2TfLX4CDFNM+8BA/5o/YLaeKtF43w==",
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.11.0.tgz",
+                    "integrity": "sha512-H7o3uh6tIw63/8rCQJ9arLiA/lY87t3ENF2hmvnbPLSYmPp6Y+Hrql3ogGXTGrQX006OGelvnJRqshh3CrEI4w==",
                     "requires": {
-                        "@microsoft/load-themed-styles": "^1.7.13",
-                        "@uifabric/merge-styles": "^6.17.3",
-                        "@uifabric/set-version": "^1.1.3",
-                        "@uifabric/utilities": "^6.38.3",
-                        "tslib": "^1.7.1"
+                        "@microsoft/load-themed-styles": "^1.10.26",
+                        "@uifabric/merge-styles": "^7.8.10",
+                        "@uifabric/set-version": "^7.0.9",
+                        "@uifabric/utilities": "^7.15.3",
+                        "tslib": "^1.10.0"
                     },
                     "dependencies": {
                         "@uifabric/utilities": {
-                            "version": "6.39.2",
-                            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.39.2.tgz",
-                            "integrity": "sha512-JSrqFtvlGt+ZoSc4ZNNNGvTN3CnSWrd+Hc0GZqUVDVryKHCDqODop8WxIW0qrD307VK2E/r/6M7oAvT6jRhmhA==",
+                            "version": "7.15.3",
+                            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.3.tgz",
+                            "integrity": "sha512-VuVv5SHOaPrpT+fONDgnpd/871TXXfQWxCgn+fETVvhsHKskVK0MhnTbi3f6MhHJZQl2SyYCUKbnOCIWguu4eQ==",
                             "requires": {
-                                "@uifabric/merge-styles": "^6.17.4",
-                                "@uifabric/set-version": "^1.1.3",
-                                "prop-types": "^15.5.10",
-                                "tslib": "^1.7.1"
+                                "@uifabric/merge-styles": "^7.8.10",
+                                "@uifabric/set-version": "^7.0.9",
+                                "prop-types": "^15.7.2",
+                                "tslib": "^1.10.0"
                             }
+                        },
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
                         }
                     }
                 },
                 "@uifabric/utilities": {
-                    "version": "6.29.4",
-                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.29.4.tgz",
-                    "integrity": "sha512-ESyMQfJrIGy1uM0HQApW0gvKpQCZBWLLoQTGZIq8Z4ZcTUEYN4Te+6oImtn0dxI1CIK6fbQNtLvZb5fX82+jMA==",
+                    "version": "7.5.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.5.0.tgz",
+                    "integrity": "sha512-h9XwZVaKyLN3Ss4G+bXFWsmCzExID/SKbO64XPjsCIhuxVYsTg6/hDrvyU4TCEx06/ehXfdHRmyjCYL1PNdDMg==",
                     "requires": {
-                        "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-                        "@uifabric/set-version": ">=1.1.3 <2.0.0",
+                        "@uifabric/merge-styles": "^7.7.0",
+                        "@uifabric/set-version": "^7.0.2",
                         "prop-types": "^15.5.10",
                         "tslib": "^1.7.1"
                     }
@@ -1148,42 +1223,70 @@
                     "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
                     "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
                 },
+                "loose-envify": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                    "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                    "requires": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                    }
+                },
                 "office-ui-fabric-react": {
-                    "version": "6.143.0",
-                    "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.143.0.tgz",
-                    "integrity": "sha512-JXV1h8upR+WPYQ7SuJFgp9XuLrJUDT9QjI7bzbyY+dpwjKCX0D22BlTfi7O52IdDt4eFesJofN8DfW0A/opvMw==",
+                    "version": "7.59.0",
+                    "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.59.0.tgz",
+                    "integrity": "sha512-bZg1Msffb7DKAawxzxmUYMEv+me6FzdPvRKbrG7pQrj/rRR8ofPbo43NRFfFmOdHnNs7290H0Cwpu3kRk+6msg==",
                     "requires": {
                         "@microsoft/load-themed-styles": "^1.7.13",
-                        "@uifabric/foundation": ">=0.7.1 <1.0.0",
-                        "@uifabric/icons": ">=6.4.0 <7.0.0",
-                        "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-                        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                        "@uifabric/styling": ">=6.41.0 <7.0.0",
-                        "@uifabric/utilities": ">=6.29.3 <7.0.0",
+                        "@uifabric/foundation": "^7.5.0",
+                        "@uifabric/icons": "^7.3.0",
+                        "@uifabric/merge-styles": "^7.8.0",
+                        "@uifabric/react-hooks": "^7.0.1",
+                        "@uifabric/set-version": "^7.0.2",
+                        "@uifabric/styling": "^7.7.2",
+                        "@uifabric/utilities": "^7.5.0",
                         "prop-types": "^15.5.10",
                         "tslib": "^1.7.1"
                     }
                 },
+                "prop-types": {
+                    "version": "15.7.2",
+                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+                    "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+                    "requires": {
+                        "loose-envify": "^1.4.0",
+                        "object-assign": "^4.1.1",
+                        "react-is": "^16.8.1"
+                    }
+                },
                 "react": {
-                    "version": "16.7.0",
-                    "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-                    "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+                    "version": "16.8.5",
+                    "resolved": "https://registry.npmjs.org/react/-/react-16.8.5.tgz",
+                    "integrity": "sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==",
                     "requires": {
                         "loose-envify": "^1.1.0",
                         "object-assign": "^4.1.1",
                         "prop-types": "^15.6.2",
-                        "scheduler": "^0.12.0"
+                        "scheduler": "^0.13.5"
                     }
                 },
                 "react-dom": {
-                    "version": "16.7.0",
-                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-                    "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+                    "version": "16.8.5",
+                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.5.tgz",
+                    "integrity": "sha512-VIEIvZLpFafsfu4kgmftP5L8j7P1f0YThfVTrANMhZUFMDOsA6e0kfR6wxw/8xxKs4NB59TZYbxNdPCDW34x4w==",
                     "requires": {
                         "loose-envify": "^1.1.0",
                         "object-assign": "^4.1.1",
                         "prop-types": "^15.6.2",
-                        "scheduler": "^0.12.0"
+                        "scheduler": "^0.13.5"
+                    }
+                },
+                "scheduler": {
+                    "version": "0.13.6",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+                    "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
                     }
                 },
                 "tslib": {
@@ -1199,38 +1302,38 @@
             }
         },
         "@microsoft/sp-component-base": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.8.2.tgz",
-            "integrity": "sha512-8v7YOYgolyMuBzFrdMvLIalXTpBt4REvy//csoAsDudshjKI0trBDLcjaryjnshz33bzcLvaZArsfRXl3C4pEw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.10.0.tgz",
+            "integrity": "sha512-9XEkYGJfVaGGqcBZ87maH8h76ohQEIqRr0wOhvVQ4ME45SK64zoCX35aOazNU28TYbqphCMSLKYS/JQSyRjuiA==",
             "requires": {
-                "@microsoft/decorators": "1.8.2",
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-dynamic-data": "1.8.2",
-                "@microsoft/sp-http": "1.8.2",
-                "@microsoft/sp-loader": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
-                "@microsoft/sp-module-interfaces": "1.8.2",
-                "@microsoft/sp-page-context": "1.8.2",
+                "@microsoft/decorators": "1.10.0",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-dynamic-data": "1.10.0",
+                "@microsoft/sp-http": "1.10.0",
+                "@microsoft/sp-loader": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
+                "@microsoft/sp-page-context": "1.10.0",
                 "@types/es6-promise": "0.0.33",
                 "@types/webpack-env": "1.13.1"
             }
         },
         "@microsoft/sp-core-library": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.8.2.tgz",
-            "integrity": "sha512-RW06oLu7sdMjq6vNtTFhvsQ7R7Ix5oJZqefC2J7p23yBWNNatmcwaBqM01SVdAsHd1coKwq3eU/0YMhzuaxKQw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.10.0.tgz",
+            "integrity": "sha512-np8GKJ90GJw5Qc1ZttYXYwwypupNxhcnWJ3Xm3tTgvDvkFyeTU0tOjUGKp9cPOBsUADxMIRtruUEBsi8Ip73yQ==",
             "requires": {
-                "@microsoft/sp-lodash-subset": "1.8.2",
-                "@microsoft/sp-module-interfaces": "1.8.2",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
                 "@types/es6-promise": "0.0.33",
                 "@types/webpack-env": "1.13.1"
             },
             "dependencies": {
                 "@microsoft/sp-lodash-subset": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.8.2.tgz",
-                    "integrity": "sha512-PTJuBAqqgxJ6xo8OQWS4sTPOyzgXzPyT60BTHyZJd8ozDoeo3lrTssmXgOaAygMUE+VglyoH7YRNAv+fg/tOgQ==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.10.0.tgz",
+                    "integrity": "sha512-DxBSb+3nN0XWmo3swC2nva4VKaCNvrzNXSnr7kfqzdXga9phi8MWBf1HTBophI8PnkxlkV1fEWgs0c7pEuuYFw==",
                     "requires": {
                         "@types/lodash": "4.14.117",
                         "@types/webpack-env": "1.13.1",
@@ -1238,19 +1341,19 @@
                     }
                 },
                 "@microsoft/sp-module-interfaces": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.8.2.tgz",
-                    "integrity": "sha512-vuwmEHZ1dP9Q5/irqpTJynkHmyxP2vfn05Bdehzd/ktlvf4CtUjgVIRXuOCPufGe5fvr96IMKLlhOzifS5sUBw==",
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.10.0.tgz",
+                    "integrity": "sha512-OGmqAmE8TbJF/1WWi2VwKtlxenUL/vu1d5h4ev87Gd3xvusTMkglVlMhNzePMYVYdzdszUVgTTvBeDV/c8tVEg==",
                     "requires": {
-                        "@types/node": "8.5.8",
+                        "@types/node": "8.10.54",
                         "@types/z-schema": "3.16.31",
                         "z-schema": "~3.18.3"
                     }
                 },
-                "@types/lodash": {
-                    "version": "4.14.117",
-                    "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-                    "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw=="
+                "@types/node": {
+                    "version": "8.10.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+                    "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg=="
                 },
                 "tslib": {
                     "version": "1.9.3",
@@ -1260,22 +1363,24 @@
             }
         },
         "@microsoft/sp-diagnostics": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.8.2.tgz",
-            "integrity": "sha512-l7qRUQduWG9waFgIP08E922PY+ea7xa2HZiEUDA6pdSOXbci2R9uo3fgL2Un5e63ZPKa5E1/0jtm1+xtgQkutA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.10.0.tgz",
+            "integrity": "sha512-LDQBjEW+S8aGumcfTdPSxC1Vosq5jzmXnYj+xvgfKqCnbo+VV8rTCyUYNENGb7+V2qyB9Q/o9ddm41aUxSg+Tg==",
             "requires": {
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2"
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0"
             }
         },
         "@microsoft/sp-dynamic-data": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.8.2.tgz",
-            "integrity": "sha512-oC4220aH1ooU+VU9ADgnEeZ6YmWZfqvFaFG5vd2EL3jzTYiIxGLvBZOfDGKnsgmaDoWC7lXIYncoG0Os3rh/6w==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.10.0.tgz",
+            "integrity": "sha512-XXTnLWeEcEDq3dcG+e0UV2HlmW/NUuuSaqU3O05xNUbx0VQJU5abuO34DGxwFyoKRp9NhG9iem1FExQiyijWDQ==",
             "requires": {
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
+                "@types/es6-promise": "0.0.33",
                 "@types/webpack-env": "1.13.1",
                 "tslib": "~1.9.3"
             },
@@ -1288,351 +1393,38 @@
             }
         },
         "@microsoft/sp-extension-base": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.8.2.tgz",
-            "integrity": "sha512-kBoV6fIhM25ORZM5iA+HTiFX5jm5oLaue8nHnyYCFyATy14wSSG9i47OF3OxMsATY4qMaQ8W2YQIaWu3Sdnhvw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.10.0.tgz",
+            "integrity": "sha512-jvWjJhy/5DkKhU6NzHyg/uDobXg8lVR6O/i9blZ14TuxFOyF+MHeoGNaK2f8wrxGUohiedNrjAMnKTVnsLahHA==",
             "requires": {
-                "@microsoft/decorators": "1.8.2",
-                "@microsoft/sp-component-base": "1.8.2",
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-http": "1.8.2",
-                "@microsoft/sp-loader": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
-                "@microsoft/sp-module-interfaces": "1.8.2",
-                "@microsoft/sp-page-context": "1.8.2",
+                "@microsoft/decorators": "1.10.0",
+                "@microsoft/sp-component-base": "1.10.0",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-http": "1.10.0",
+                "@microsoft/sp-loader": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
+                "@microsoft/sp-page-context": "1.10.0",
                 "@types/es6-promise": "0.0.33",
                 "@types/webpack-env": "1.13.1"
-            },
-            "dependencies": {
-                "@microsoft/decorators": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.8.2.tgz",
-                    "integrity": "sha512-1tWDtxh6Mks5JjqI2yRPBD3ZaOT1DhDh6+Z/Lj1LWA+OU4CnIkl2P3uGkiKhchXlgHBeKUidFGRVrv0parfTRQ==",
-                    "requires": {
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/office-ui-fabric-react-bundle": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.8.2.tgz",
-                    "integrity": "sha512-KQ07naCdJXW6nquDDEP/ydb8SHoFj1Kcsldj5qREcdJIZfUkrlxXRpFlgJoVKdPF3sYomDSssTCQf8pmy0uicA==",
-                    "requires": {
-                        "@types/react": "16.4.2",
-                        "@types/webpack-env": "1.13.1",
-                        "@uifabric/icons": "6.4.0",
-                        "office-ui-fabric-react": "6.143.0",
-                        "react": "16.7.0",
-                        "react-dom": "16.7.0",
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/sp-component-base": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.8.2.tgz",
-                    "integrity": "sha512-8v7YOYgolyMuBzFrdMvLIalXTpBt4REvy//csoAsDudshjKI0trBDLcjaryjnshz33bzcLvaZArsfRXl3C4pEw==",
-                    "requires": {
-                        "@microsoft/decorators": "1.8.2",
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-dynamic-data": "1.8.2",
-                        "@microsoft/sp-http": "1.8.2",
-                        "@microsoft/sp-loader": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-module-interfaces": "1.8.2",
-                        "@microsoft/sp-page-context": "1.8.2",
-                        "@types/es6-promise": "0.0.33",
-                        "@types/webpack-env": "1.13.1"
-                    }
-                },
-                "@microsoft/sp-diagnostics": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.8.2.tgz",
-                    "integrity": "sha512-l7qRUQduWG9waFgIP08E922PY+ea7xa2HZiEUDA6pdSOXbci2R9uo3fgL2Un5e63ZPKa5E1/0jtm1+xtgQkutA==",
-                    "requires": {
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2"
-                    }
-                },
-                "@microsoft/sp-dynamic-data": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.8.2.tgz",
-                    "integrity": "sha512-oC4220aH1ooU+VU9ADgnEeZ6YmWZfqvFaFG5vd2EL3jzTYiIxGLvBZOfDGKnsgmaDoWC7lXIYncoG0Os3rh/6w==",
-                    "requires": {
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@types/webpack-env": "1.13.1",
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/sp-http": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.8.2.tgz",
-                    "integrity": "sha512-lTVQ6oI1yjc4M0yeyQHrivy+6SNp1q4xUQ3skBWY25b55zPIJHH3m/nOvHy2q44b9eWurdjq7bS1T19lrf7+LQ==",
-                    "requires": {
-                        "@microsoft/microsoft-graph-client": "~1.1.0",
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@types/adal-angular": "1.0.1",
-                        "adal-angular": "1.0.16",
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/sp-loader": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.8.2.tgz",
-                    "integrity": "sha512-Q1LKFV8jOqWV6451dpDFwyaMK2Hw4X+tcnX5hFqltL1O1r/rD2P7PJkLi8lpL8sqWJ9JhTDDY8+pWD1YYC6W6A==",
-                    "requires": {
-                        "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-dynamic-data": "1.8.2",
-                        "@microsoft/sp-http": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-module-interfaces": "1.8.2",
-                        "@microsoft/sp-odata-types": "1.8.2",
-                        "@microsoft/sp-page-context": "1.8.2",
-                        "@microsoft/sp-polyfills": "1.8.2",
-                        "@types/es6-promise": "0.0.33",
-                        "@types/node": "8.5.8",
-                        "@types/react": "16.4.2",
-                        "@types/react-dom": "16.0.5",
-                        "@types/requirejs": "2.1.29",
-                        "@types/webpack-env": "1.13.1",
-                        "@uifabric/utilities": "6.29.4",
-                        "office-ui-fabric-react": "6.143.0",
-                        "react": "16.7.0",
-                        "react-dom": "16.7.0",
-                        "requirejs": "2.1.20",
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/sp-lodash-subset": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.8.2.tgz",
-                    "integrity": "sha512-PTJuBAqqgxJ6xo8OQWS4sTPOyzgXzPyT60BTHyZJd8ozDoeo3lrTssmXgOaAygMUE+VglyoH7YRNAv+fg/tOgQ==",
-                    "requires": {
-                        "@types/lodash": "4.14.117",
-                        "@types/webpack-env": "1.13.1",
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/sp-module-interfaces": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.8.2.tgz",
-                    "integrity": "sha512-vuwmEHZ1dP9Q5/irqpTJynkHmyxP2vfn05Bdehzd/ktlvf4CtUjgVIRXuOCPufGe5fvr96IMKLlhOzifS5sUBw==",
-                    "requires": {
-                        "@types/node": "8.5.8",
-                        "@types/z-schema": "3.16.31",
-                        "z-schema": "~3.18.3"
-                    }
-                },
-                "@microsoft/sp-odata-types": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.8.2.tgz",
-                    "integrity": "sha512-reRLI23NHfUwJAcQmTGl3z80ncqRlW6YSs8OoZFkIEsYsnuv7P+xwJnhH+4im8ywJ+3ESEOZj6ZtdrvUM9PcmA==",
-                    "requires": {
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/sp-page-context": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.8.2.tgz",
-                    "integrity": "sha512-TkVV/h5XEJUfGH/80y0YPD3jWEli8V3Z+Xsnub0ZjC5lU492J1JLFDeNMqIlG25vhIeL+V+Le9hxU9cTNW4hsA==",
-                    "requires": {
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-diagnostics": "1.8.2",
-                        "@microsoft/sp-dynamic-data": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2",
-                        "@microsoft/sp-odata-types": "1.8.2",
-                        "@types/es6-promise": "0.0.33",
-                        "@types/webpack-env": "1.13.1",
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@microsoft/sp-polyfills": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.8.2.tgz",
-                    "integrity": "sha512-0Zl7ipeFws2PJYbtVQ0UMWzBExZuH5qQZuzf25KXmYsQd8tgMNBI3C1OCnTqbTYVx8LhdJtlf5y5D1mYLV4Raw==",
-                    "requires": {
-                        "@types/webpack-env": "1.13.1",
-                        "es6-collections": "0.5.6",
-                        "es6-promise": "4.1.1",
-                        "tslib": "~1.9.3",
-                        "whatwg-fetch": "2.0.3",
-                        "whatwg-url": "4.7.1"
-                    }
-                },
-                "@types/lodash": {
-                    "version": "4.14.117",
-                    "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-                    "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw=="
-                },
-                "@types/react": {
-                    "version": "16.4.2",
-                    "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.2.tgz",
-                    "integrity": "sha512-oVcVteCDNiVc/fkDjowRfAZQDEOR76j3CJ3FvwXNvfV6zJguhghy1lMgpAzYox+9AZsWch+JPV6Imml3wvIUeg==",
-                    "requires": {
-                        "csstype": "^2.2.0"
-                    }
-                },
-                "@types/react-dom": {
-                    "version": "16.0.5",
-                    "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.5.tgz",
-                    "integrity": "sha512-ony2hEYlGXCLWNAWWgbsHR7qVvDbeMRFc5b43+7dhj3n+zXzxz81HV9Yjpc3JD8vLCiwYoSLqFCI6bD0+0zG2Q==",
-                    "requires": {
-                        "@types/node": "*",
-                        "@types/react": "*"
-                    }
-                },
-                "@uifabric/icons": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.4.0.tgz",
-                    "integrity": "sha512-pbKu3OnWaRIeDqMFhicDrrcqicxNqoHpJpknZR9N2xxoPnYMnt2ZOhBNnAxoVVcxHlWkFNg0rvFrOAQGn+S5/Q==",
-                    "requires": {
-                        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                        "@uifabric/styling": ">=6.41.0 <7.0.0",
-                        "tslib": "^1.7.1"
-                    }
-                },
-                "@uifabric/merge-styles": {
-                    "version": "6.17.4",
-                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.17.4.tgz",
-                    "integrity": "sha512-IYg+LiyetyqSadHTHYYUfpYKWdlKIF5LTmumMX2Mp0HtgAc51KOf2xx2XX6M35jERIGyBSvQruOXjvJXVGsXSg==",
-                    "requires": {
-                        "@uifabric/set-version": "^1.1.3",
-                        "tslib": "^1.7.1"
-                    }
-                },
-                "@uifabric/styling": {
-                    "version": "6.47.6",
-                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.47.6.tgz",
-                    "integrity": "sha512-nTsuwEbPTUofPFX3/RZ8FprRUTI02GsRffdNIxannHuVBntHAbKB0CrvQ2TfLX4CDFNM+8BA/5o/YLaeKtF43w==",
-                    "requires": {
-                        "@microsoft/load-themed-styles": "^1.7.13",
-                        "@uifabric/merge-styles": "^6.17.3",
-                        "@uifabric/set-version": "^1.1.3",
-                        "@uifabric/utilities": "^6.38.3",
-                        "tslib": "^1.7.1"
-                    },
-                    "dependencies": {
-                        "@uifabric/utilities": {
-                            "version": "6.39.2",
-                            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.39.2.tgz",
-                            "integrity": "sha512-JSrqFtvlGt+ZoSc4ZNNNGvTN3CnSWrd+Hc0GZqUVDVryKHCDqODop8WxIW0qrD307VK2E/r/6M7oAvT6jRhmhA==",
-                            "requires": {
-                                "@uifabric/merge-styles": "^6.17.4",
-                                "@uifabric/set-version": "^1.1.3",
-                                "prop-types": "^15.5.10",
-                                "tslib": "^1.7.1"
-                            }
-                        }
-                    }
-                },
-                "@uifabric/utilities": {
-                    "version": "6.29.4",
-                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.29.4.tgz",
-                    "integrity": "sha512-ESyMQfJrIGy1uM0HQApW0gvKpQCZBWLLoQTGZIq8Z4ZcTUEYN4Te+6oImtn0dxI1CIK6fbQNtLvZb5fX82+jMA==",
-                    "requires": {
-                        "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-                        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                        "prop-types": "^15.5.10",
-                        "tslib": "^1.7.1"
-                    }
-                },
-                "es6-promise": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-                    "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
-                },
-                "office-ui-fabric-react": {
-                    "version": "6.143.0",
-                    "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.143.0.tgz",
-                    "integrity": "sha512-JXV1h8upR+WPYQ7SuJFgp9XuLrJUDT9QjI7bzbyY+dpwjKCX0D22BlTfi7O52IdDt4eFesJofN8DfW0A/opvMw==",
-                    "requires": {
-                        "@microsoft/load-themed-styles": "^1.7.13",
-                        "@uifabric/foundation": ">=0.7.1 <1.0.0",
-                        "@uifabric/icons": ">=6.4.0 <7.0.0",
-                        "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-                        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                        "@uifabric/styling": ">=6.41.0 <7.0.0",
-                        "@uifabric/utilities": ">=6.29.3 <7.0.0",
-                        "prop-types": "^15.5.10",
-                        "tslib": "^1.7.1"
-                    }
-                },
-                "react": {
-                    "version": "16.7.0",
-                    "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-                    "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
-                    "requires": {
-                        "loose-envify": "^1.1.0",
-                        "object-assign": "^4.1.1",
-                        "prop-types": "^15.6.2",
-                        "scheduler": "^0.12.0"
-                    }
-                },
-                "react-dom": {
-                    "version": "16.7.0",
-                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-                    "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
-                    "requires": {
-                        "loose-envify": "^1.1.0",
-                        "object-assign": "^4.1.1",
-                        "prop-types": "^15.6.2",
-                        "scheduler": "^0.12.0"
-                    }
-                },
-                "tslib": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-                    "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-                },
-                "whatwg-fetch": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-                    "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-                }
             }
         },
         "@microsoft/sp-http": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.8.2.tgz",
-            "integrity": "sha512-lTVQ6oI1yjc4M0yeyQHrivy+6SNp1q4xUQ3skBWY25b55zPIJHH3m/nOvHy2q44b9eWurdjq7bS1T19lrf7+LQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.10.0.tgz",
+            "integrity": "sha512-8H76ORi4NV3ByNvvvENgucH7xdezdFGlJdxlOYIkzhyWgYsm/IEzFCNNBOChQk8kmlP/PqF146Ft6PIYgrZ6og==",
             "requires": {
                 "@microsoft/microsoft-graph-client": "~1.1.0",
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
                 "@types/adal-angular": "1.0.1",
                 "adal-angular": "1.0.16",
+                "msal": "1.1.3",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
-                "@microsoft/sp-diagnostics": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.8.2.tgz",
-                    "integrity": "sha512-l7qRUQduWG9waFgIP08E922PY+ea7xa2HZiEUDA6pdSOXbci2R9uo3fgL2Un5e63ZPKa5E1/0jtm1+xtgQkutA==",
-                    "requires": {
-                        "@microsoft/sp-core-library": "1.8.2",
-                        "@microsoft/sp-lodash-subset": "1.8.2"
-                    }
-                },
-                "@microsoft/sp-lodash-subset": {
-                    "version": "1.8.2",
-                    "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.8.2.tgz",
-                    "integrity": "sha512-PTJuBAqqgxJ6xo8OQWS4sTPOyzgXzPyT60BTHyZJd8ozDoeo3lrTssmXgOaAygMUE+VglyoH7YRNAv+fg/tOgQ==",
-                    "requires": {
-                        "@types/lodash": "4.14.117",
-                        "@types/webpack-env": "1.13.1",
-                        "tslib": "~1.9.3"
-                    }
-                },
-                "@types/lodash": {
-                    "version": "4.14.117",
-                    "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-                    "integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw=="
-                },
                 "tslib": {
                     "version": "1.9.3",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -1641,30 +1433,32 @@
             }
         },
         "@microsoft/sp-loader": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.8.2.tgz",
-            "integrity": "sha512-Q1LKFV8jOqWV6451dpDFwyaMK2Hw4X+tcnX5hFqltL1O1r/rD2P7PJkLi8lpL8sqWJ9JhTDDY8+pWD1YYC6W6A==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.10.0.tgz",
+            "integrity": "sha512-fJs0kXHK/QiF5JkkI64bZbdC0nGYEanua5MjawZxQO2c8KY9uVK/h2cJXIN9OnAL5lbn5gJD5aE4jQe2z4BBgQ==",
             "requires": {
-                "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-dynamic-data": "1.8.2",
-                "@microsoft/sp-http": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
-                "@microsoft/sp-module-interfaces": "1.8.2",
-                "@microsoft/sp-odata-types": "1.8.2",
-                "@microsoft/sp-page-context": "1.8.2",
-                "@microsoft/sp-polyfills": "1.8.2",
+                "@microsoft/loader-raw-script": "1.2.182",
+                "@microsoft/office-ui-fabric-react-bundle": "1.10.0",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-dynamic-data": "1.10.0",
+                "@microsoft/sp-http": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
+                "@microsoft/sp-odata-types": "1.10.0",
+                "@microsoft/sp-page-context": "1.10.0",
+                "@microsoft/sp-polyfills": "1.10.0",
                 "@types/es6-promise": "0.0.33",
-                "@types/node": "8.5.8",
-                "@types/react": "16.4.2",
-                "@types/react-dom": "16.0.5",
+                "@types/react": "16.8.8",
+                "@types/react-dom": "16.8.3",
                 "@types/requirejs": "2.1.29",
                 "@types/webpack-env": "1.13.1",
-                "@uifabric/utilities": "6.29.4",
-                "office-ui-fabric-react": "6.143.0",
-                "react": "16.7.0",
-                "react-dom": "16.7.0",
+                "@uifabric/utilities": "7.5.0",
+                "exports-loader": "~0.6.4",
+                "office-ui-fabric-react": "7.59.0",
+                "raw-loader": "~0.5.1",
+                "react": "16.8.5",
+                "react-dom": "16.8.5",
                 "requirejs": "2.1.20",
                 "tslib": "~1.9.3"
             },
@@ -1677,9 +1471,9 @@
             }
         },
         "@microsoft/sp-lodash-subset": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.8.2.tgz",
-            "integrity": "sha512-PTJuBAqqgxJ6xo8OQWS4sTPOyzgXzPyT60BTHyZJd8ozDoeo3lrTssmXgOaAygMUE+VglyoH7YRNAv+fg/tOgQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.10.0.tgz",
+            "integrity": "sha512-DxBSb+3nN0XWmo3swC2nva4VKaCNvrzNXSnr7kfqzdXga9phi8MWBf1HTBophI8PnkxlkV1fEWgs0c7pEuuYFw==",
             "requires": {
                 "@types/lodash": "4.14.117",
                 "@types/webpack-env": "1.13.1",
@@ -1694,19 +1488,26 @@
             }
         },
         "@microsoft/sp-module-interfaces": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.8.2.tgz",
-            "integrity": "sha512-vuwmEHZ1dP9Q5/irqpTJynkHmyxP2vfn05Bdehzd/ktlvf4CtUjgVIRXuOCPufGe5fvr96IMKLlhOzifS5sUBw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.10.0.tgz",
+            "integrity": "sha512-OGmqAmE8TbJF/1WWi2VwKtlxenUL/vu1d5h4ev87Gd3xvusTMkglVlMhNzePMYVYdzdszUVgTTvBeDV/c8tVEg==",
             "requires": {
-                "@types/node": "8.5.8",
+                "@types/node": "8.10.54",
                 "@types/z-schema": "3.16.31",
                 "z-schema": "~3.18.3"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "8.10.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+                    "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg=="
+                }
             }
         },
         "@microsoft/sp-odata-types": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.8.2.tgz",
-            "integrity": "sha512-reRLI23NHfUwJAcQmTGl3z80ncqRlW6YSs8OoZFkIEsYsnuv7P+xwJnhH+4im8ywJ+3ESEOZj6ZtdrvUM9PcmA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.10.0.tgz",
+            "integrity": "sha512-O3kGcABicM5mgG9jUzqTU6tXZZPIGRZcM6uGry+v8M31r+ktptXyOOd7DkReNzFFxDJuXnqTAjusHMVx1N5+2A==",
             "requires": {
                 "tslib": "~1.9.3"
             },
@@ -1719,15 +1520,15 @@
             }
         },
         "@microsoft/sp-page-context": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.8.2.tgz",
-            "integrity": "sha512-TkVV/h5XEJUfGH/80y0YPD3jWEli8V3Z+Xsnub0ZjC5lU492J1JLFDeNMqIlG25vhIeL+V+Le9hxU9cTNW4hsA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.10.0.tgz",
+            "integrity": "sha512-EWqbL299gqlVUtETsogQDf3OacusLC0YoM0Yu4/dxiCbTJCE6FjaR4oDYYUa30HbqAe/Tmko3c5Buah7TkaB/g==",
             "requires": {
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-dynamic-data": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
-                "@microsoft/sp-odata-types": "1.8.2",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-dynamic-data": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-odata-types": "1.10.0",
                 "@types/es6-promise": "0.0.33",
                 "@types/webpack-env": "1.13.1",
                 "tslib": "~1.9.3"
@@ -1741,9 +1542,9 @@
             }
         },
         "@microsoft/sp-polyfills": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.8.2.tgz",
-            "integrity": "sha512-0Zl7ipeFws2PJYbtVQ0UMWzBExZuH5qQZuzf25KXmYsQd8tgMNBI3C1OCnTqbTYVx8LhdJtlf5y5D1mYLV4Raw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.10.0.tgz",
+            "integrity": "sha512-oboAg9zAH/P86CgG+8RA8wpL9aLJtYtchcVjnQxTYp3wMvHtNWEysHWBHtjIapTLEKXbPwNQ8Apnsy2TstNcZg==",
             "requires": {
                 "@types/webpack-env": "1.13.1",
                 "es6-collections": "0.5.6",
@@ -1771,24 +1572,24 @@
             }
         },
         "@microsoft/sp-property-pane": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.8.2.tgz",
-            "integrity": "sha512-XGHxlx4vyQIA9TeeYB38OQcHQ+ehn/SWVMS6HM+hJmjdCRWFjHIpCYamvuWyrL8hkOFLvvv7w8mPt23aLjSTag==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.10.0.tgz",
+            "integrity": "sha512-15uU56CSIkySBC19hARSL9bh24AeaXbnTrrqxROiKBy/1MUDIL+MocdDDwp23/qn4IvhToRwSbLV/3L9m9Uzew==",
             "requires": {
-                "@microsoft/decorators": "1.8.2",
-                "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-                "@microsoft/sp-component-base": "1.8.2",
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-dynamic-data": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
+                "@microsoft/decorators": "1.10.0",
+                "@microsoft/office-ui-fabric-react-bundle": "1.10.0",
+                "@microsoft/sp-component-base": "1.10.0",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-dynamic-data": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
                 "@types/es6-promise": "0.0.33",
-                "@types/react": "16.4.2",
-                "@types/react-dom": "16.0.5",
+                "@types/react": "16.8.8",
+                "@types/react-dom": "16.8.3",
                 "@types/webpack-env": "1.13.1",
-                "office-ui-fabric-react": "6.143.0",
-                "react": "16.7.0",
-                "react-dom": "16.7.0",
+                "office-ui-fabric-react": "7.59.0",
+                "react": "16.8.5",
+                "react-dom": "16.8.5",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
@@ -1799,34 +1600,466 @@
                 }
             }
         },
-        "@microsoft/sp-webpart-base": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.8.2.tgz",
-            "integrity": "sha512-6dj0pd1iNHsxyRG4+ORyItVd/lqbSuXi473kO2nuOzdHW+LqWwriXq5qaWq2tJ9eEJRu9J+ONqhU4rEL99GdMg==",
+        "@microsoft/sp-search-extensibility": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-search-extensibility/-/sp-search-extensibility-1.10.0.tgz",
+            "integrity": "sha512-ANeV0+4PYuoU7aXz1Hh37B+igXn/il0hKjbvAlhtvVubb2Sgu7axSsM+0PlLxljyhWk2McXovrmlWR4oW8jrAQ==",
             "requires": {
-                "@microsoft/decorators": "1.8.2",
-                "@microsoft/load-themed-styles": "1.8.62",
-                "@microsoft/sp-component-base": "1.8.2",
-                "@microsoft/sp-core-library": "1.8.2",
-                "@microsoft/sp-diagnostics": "1.8.2",
-                "@microsoft/sp-dynamic-data": "1.8.2",
-                "@microsoft/sp-http": "1.8.2",
-                "@microsoft/sp-loader": "1.8.2",
-                "@microsoft/sp-lodash-subset": "1.8.2",
-                "@microsoft/sp-module-interfaces": "1.8.2",
-                "@microsoft/sp-page-context": "1.8.2",
-                "@microsoft/sp-property-pane": "1.8.2",
-                "@microsoft/teams-js": "1.4.1",
+                "@microsoft/decorators": "1.10.0",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-extension-base": "1.10.0",
+                "@microsoft/sp-loader": "1.10.0",
+                "@microsoft/sp-page-context": "1.10.0",
                 "@types/es6-promise": "0.0.33",
+                "@types/webpack-env": "1.13.1"
+            },
+            "dependencies": {
+                "@microsoft/decorators": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.10.0.tgz",
+                    "integrity": "sha512-4D4DaG01XMNM253yFmLvtucPfdzj3UABpQ/4/02/Pnvt9fXGgg/TCxSApto4u8Vxka64uO7LCxMG5Fd1qv4b8Q==",
+                    "requires": {
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/load-themed-styles": {
+                    "version": "1.10.41",
+                    "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.41.tgz",
+                    "integrity": "sha512-oA16YDh9us9QVjlvCBdg50blzvChuD2zLM0awnuHC0BivV2P2Og2sD9qh12znH8w82yDyCrqj9Qiie7xI9qJ/g=="
+                },
+                "@microsoft/office-ui-fabric-react-bundle": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.10.0.tgz",
+                    "integrity": "sha512-T2Rvf8bdRQt7PHH9vLfc7lkkEzfXIAwqTPqIW7IkwQwORJ8oeYJdEO92SqQOkGtJdxLtXt6dQm0f9G8YH5huDw==",
+                    "requires": {
+                        "@types/react": "16.8.8",
+                        "@types/webpack-env": "1.13.1",
+                        "@uifabric/icons": "7.3.0",
+                        "office-ui-fabric-react": "7.59.0",
+                        "react": "16.8.5",
+                        "react-dom": "16.8.5",
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/sp-component-base": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.10.0.tgz",
+                    "integrity": "sha512-9XEkYGJfVaGGqcBZ87maH8h76ohQEIqRr0wOhvVQ4ME45SK64zoCX35aOazNU28TYbqphCMSLKYS/JQSyRjuiA==",
+                    "requires": {
+                        "@microsoft/decorators": "1.10.0",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-dynamic-data": "1.10.0",
+                        "@microsoft/sp-http": "1.10.0",
+                        "@microsoft/sp-loader": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@microsoft/sp-page-context": "1.10.0",
+                        "@types/es6-promise": "0.0.33",
+                        "@types/webpack-env": "1.13.1"
+                    }
+                },
+                "@microsoft/sp-core-library": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.10.0.tgz",
+                    "integrity": "sha512-np8GKJ90GJw5Qc1ZttYXYwwypupNxhcnWJ3Xm3tTgvDvkFyeTU0tOjUGKp9cPOBsUADxMIRtruUEBsi8Ip73yQ==",
+                    "requires": {
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@types/es6-promise": "0.0.33",
+                        "@types/webpack-env": "1.13.1"
+                    }
+                },
+                "@microsoft/sp-diagnostics": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.10.0.tgz",
+                    "integrity": "sha512-LDQBjEW+S8aGumcfTdPSxC1Vosq5jzmXnYj+xvgfKqCnbo+VV8rTCyUYNENGb7+V2qyB9Q/o9ddm41aUxSg+Tg==",
+                    "requires": {
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0"
+                    }
+                },
+                "@microsoft/sp-dynamic-data": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.10.0.tgz",
+                    "integrity": "sha512-XXTnLWeEcEDq3dcG+e0UV2HlmW/NUuuSaqU3O05xNUbx0VQJU5abuO34DGxwFyoKRp9NhG9iem1FExQiyijWDQ==",
+                    "requires": {
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@types/es6-promise": "0.0.33",
+                        "@types/webpack-env": "1.13.1",
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/sp-extension-base": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.10.0.tgz",
+                    "integrity": "sha512-jvWjJhy/5DkKhU6NzHyg/uDobXg8lVR6O/i9blZ14TuxFOyF+MHeoGNaK2f8wrxGUohiedNrjAMnKTVnsLahHA==",
+                    "requires": {
+                        "@microsoft/decorators": "1.10.0",
+                        "@microsoft/sp-component-base": "1.10.0",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-http": "1.10.0",
+                        "@microsoft/sp-loader": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@microsoft/sp-page-context": "1.10.0",
+                        "@types/es6-promise": "0.0.33",
+                        "@types/webpack-env": "1.13.1"
+                    }
+                },
+                "@microsoft/sp-http": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.10.0.tgz",
+                    "integrity": "sha512-8H76ORi4NV3ByNvvvENgucH7xdezdFGlJdxlOYIkzhyWgYsm/IEzFCNNBOChQk8kmlP/PqF146Ft6PIYgrZ6og==",
+                    "requires": {
+                        "@microsoft/microsoft-graph-client": "~1.1.0",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@types/adal-angular": "1.0.1",
+                        "adal-angular": "1.0.16",
+                        "msal": "1.1.3",
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/sp-loader": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.10.0.tgz",
+                    "integrity": "sha512-fJs0kXHK/QiF5JkkI64bZbdC0nGYEanua5MjawZxQO2c8KY9uVK/h2cJXIN9OnAL5lbn5gJD5aE4jQe2z4BBgQ==",
+                    "requires": {
+                        "@microsoft/loader-raw-script": "1.2.182",
+                        "@microsoft/office-ui-fabric-react-bundle": "1.10.0",
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-dynamic-data": "1.10.0",
+                        "@microsoft/sp-http": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-module-interfaces": "1.10.0",
+                        "@microsoft/sp-odata-types": "1.10.0",
+                        "@microsoft/sp-page-context": "1.10.0",
+                        "@microsoft/sp-polyfills": "1.10.0",
+                        "@types/es6-promise": "0.0.33",
+                        "@types/react": "16.8.8",
+                        "@types/react-dom": "16.8.3",
+                        "@types/requirejs": "2.1.29",
+                        "@types/webpack-env": "1.13.1",
+                        "@uifabric/utilities": "7.5.0",
+                        "exports-loader": "~0.6.4",
+                        "office-ui-fabric-react": "7.59.0",
+                        "raw-loader": "~0.5.1",
+                        "react": "16.8.5",
+                        "react-dom": "16.8.5",
+                        "requirejs": "2.1.20",
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/sp-lodash-subset": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.10.0.tgz",
+                    "integrity": "sha512-DxBSb+3nN0XWmo3swC2nva4VKaCNvrzNXSnr7kfqzdXga9phi8MWBf1HTBophI8PnkxlkV1fEWgs0c7pEuuYFw==",
+                    "requires": {
+                        "@types/lodash": "4.14.117",
+                        "@types/webpack-env": "1.13.1",
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/sp-module-interfaces": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.10.0.tgz",
+                    "integrity": "sha512-OGmqAmE8TbJF/1WWi2VwKtlxenUL/vu1d5h4ev87Gd3xvusTMkglVlMhNzePMYVYdzdszUVgTTvBeDV/c8tVEg==",
+                    "requires": {
+                        "@types/node": "8.10.54",
+                        "@types/z-schema": "3.16.31",
+                        "z-schema": "~3.18.3"
+                    }
+                },
+                "@microsoft/sp-odata-types": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.10.0.tgz",
+                    "integrity": "sha512-O3kGcABicM5mgG9jUzqTU6tXZZPIGRZcM6uGry+v8M31r+ktptXyOOd7DkReNzFFxDJuXnqTAjusHMVx1N5+2A==",
+                    "requires": {
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/sp-page-context": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.10.0.tgz",
+                    "integrity": "sha512-EWqbL299gqlVUtETsogQDf3OacusLC0YoM0Yu4/dxiCbTJCE6FjaR4oDYYUa30HbqAe/Tmko3c5Buah7TkaB/g==",
+                    "requires": {
+                        "@microsoft/sp-core-library": "1.10.0",
+                        "@microsoft/sp-diagnostics": "1.10.0",
+                        "@microsoft/sp-dynamic-data": "1.10.0",
+                        "@microsoft/sp-lodash-subset": "1.10.0",
+                        "@microsoft/sp-odata-types": "1.10.0",
+                        "@types/es6-promise": "0.0.33",
+                        "@types/webpack-env": "1.13.1",
+                        "tslib": "~1.9.3"
+                    }
+                },
+                "@microsoft/sp-polyfills": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.10.0.tgz",
+                    "integrity": "sha512-oboAg9zAH/P86CgG+8RA8wpL9aLJtYtchcVjnQxTYp3wMvHtNWEysHWBHtjIapTLEKXbPwNQ8Apnsy2TstNcZg==",
+                    "requires": {
+                        "@types/webpack-env": "1.13.1",
+                        "es6-collections": "0.5.6",
+                        "es6-promise": "4.1.1",
+                        "tslib": "~1.9.3",
+                        "whatwg-fetch": "2.0.3",
+                        "whatwg-url": "4.7.1"
+                    }
+                },
+                "@types/node": {
+                    "version": "8.10.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+                    "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg=="
+                },
+                "@types/react": {
+                    "version": "16.8.8",
+                    "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.8.tgz",
+                    "integrity": "sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==",
+                    "requires": {
+                        "@types/prop-types": "*",
+                        "csstype": "^2.2.0"
+                    }
+                },
+                "@types/react-dom": {
+                    "version": "16.8.3",
+                    "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.3.tgz",
+                    "integrity": "sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==",
+                    "requires": {
+                        "@types/react": "*"
+                    }
+                },
+                "@uifabric/foundation": {
+                    "version": "7.5.23",
+                    "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.5.23.tgz",
+                    "integrity": "sha512-FIzJorSPmazXgiLauRufFnlhKd3W9X0x7iq5EbPHg8zwem6S87qzHn4IuXxBde9KE3LvAtflzlak+VNdXUsPdg==",
+                    "requires": {
+                        "@uifabric/merge-styles": "^7.8.10",
+                        "@uifabric/set-version": "^7.0.9",
+                        "@uifabric/styling": "^7.11.0",
+                        "@uifabric/utilities": "^7.15.3",
+                        "tslib": "^1.10.0"
+                    },
+                    "dependencies": {
+                        "@uifabric/utilities": {
+                            "version": "7.15.3",
+                            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.3.tgz",
+                            "integrity": "sha512-VuVv5SHOaPrpT+fONDgnpd/871TXXfQWxCgn+fETVvhsHKskVK0MhnTbi3f6MhHJZQl2SyYCUKbnOCIWguu4eQ==",
+                            "requires": {
+                                "@uifabric/merge-styles": "^7.8.10",
+                                "@uifabric/set-version": "^7.0.9",
+                                "prop-types": "^15.7.2",
+                                "tslib": "^1.10.0"
+                            }
+                        },
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                        }
+                    }
+                },
+                "@uifabric/icons": {
+                    "version": "7.3.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.0.tgz",
+                    "integrity": "sha512-wbcR8fJce20sPjsK2bbTC/cAZfAOFuE4dd4LHw194+8H+/dqotsowrQVp5Lu8aaHGQk+fXoiZmUy30WA9cAG4Q==",
+                    "requires": {
+                        "@uifabric/set-version": "^7.0.2",
+                        "@uifabric/styling": "^7.7.1",
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "@uifabric/merge-styles": {
+                    "version": "7.8.10",
+                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.8.10.tgz",
+                    "integrity": "sha512-VQ2GE6YVL9IGAgd7ZGpDMpwjNy4Ls4Wlb+ijugDRCK/DKgl2mX2iSUGV+fsWgiHAt8O1LQP5mvggtMPNOroSTw==",
+                    "requires": {
+                        "@uifabric/set-version": "^7.0.9",
+                        "tslib": "^1.10.0"
+                    },
+                    "dependencies": {
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                        }
+                    }
+                },
+                "@uifabric/set-version": {
+                    "version": "7.0.9",
+                    "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.9.tgz",
+                    "integrity": "sha512-YJL6WLBlFKDJcLSw1ihqW5PTFi2XMoluEvwGd2qtzp2IVbHvdbk7uIdWuTALo3dFNNqWPN8shSNUdHVATE/1jQ==",
+                    "requires": {
+                        "tslib": "^1.10.0"
+                    },
+                    "dependencies": {
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                        }
+                    }
+                },
+                "@uifabric/styling": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.11.0.tgz",
+                    "integrity": "sha512-H7o3uh6tIw63/8rCQJ9arLiA/lY87t3ENF2hmvnbPLSYmPp6Y+Hrql3ogGXTGrQX006OGelvnJRqshh3CrEI4w==",
+                    "requires": {
+                        "@microsoft/load-themed-styles": "^1.10.26",
+                        "@uifabric/merge-styles": "^7.8.10",
+                        "@uifabric/set-version": "^7.0.9",
+                        "@uifabric/utilities": "^7.15.3",
+                        "tslib": "^1.10.0"
+                    },
+                    "dependencies": {
+                        "@uifabric/utilities": {
+                            "version": "7.15.3",
+                            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.3.tgz",
+                            "integrity": "sha512-VuVv5SHOaPrpT+fONDgnpd/871TXXfQWxCgn+fETVvhsHKskVK0MhnTbi3f6MhHJZQl2SyYCUKbnOCIWguu4eQ==",
+                            "requires": {
+                                "@uifabric/merge-styles": "^7.8.10",
+                                "@uifabric/set-version": "^7.0.9",
+                                "prop-types": "^15.7.2",
+                                "tslib": "^1.10.0"
+                            }
+                        },
+                        "tslib": {
+                            "version": "1.11.1",
+                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                        }
+                    }
+                },
+                "@uifabric/utilities": {
+                    "version": "7.5.0",
+                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.5.0.tgz",
+                    "integrity": "sha512-h9XwZVaKyLN3Ss4G+bXFWsmCzExID/SKbO64XPjsCIhuxVYsTg6/hDrvyU4TCEx06/ehXfdHRmyjCYL1PNdDMg==",
+                    "requires": {
+                        "@uifabric/merge-styles": "^7.7.0",
+                        "@uifabric/set-version": "^7.0.2",
+                        "prop-types": "^15.5.10",
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "es6-promise": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                    "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+                },
+                "loose-envify": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                    "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                    "requires": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                    }
+                },
+                "office-ui-fabric-react": {
+                    "version": "7.59.0",
+                    "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.59.0.tgz",
+                    "integrity": "sha512-bZg1Msffb7DKAawxzxmUYMEv+me6FzdPvRKbrG7pQrj/rRR8ofPbo43NRFfFmOdHnNs7290H0Cwpu3kRk+6msg==",
+                    "requires": {
+                        "@microsoft/load-themed-styles": "^1.7.13",
+                        "@uifabric/foundation": "^7.5.0",
+                        "@uifabric/icons": "^7.3.0",
+                        "@uifabric/merge-styles": "^7.8.0",
+                        "@uifabric/react-hooks": "^7.0.1",
+                        "@uifabric/set-version": "^7.0.2",
+                        "@uifabric/styling": "^7.7.2",
+                        "@uifabric/utilities": "^7.5.0",
+                        "prop-types": "^15.5.10",
+                        "tslib": "^1.7.1"
+                    }
+                },
+                "prop-types": {
+                    "version": "15.7.2",
+                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+                    "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+                    "requires": {
+                        "loose-envify": "^1.4.0",
+                        "object-assign": "^4.1.1",
+                        "react-is": "^16.8.1"
+                    }
+                },
+                "react": {
+                    "version": "16.8.5",
+                    "resolved": "https://registry.npmjs.org/react/-/react-16.8.5.tgz",
+                    "integrity": "sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "prop-types": "^15.6.2",
+                        "scheduler": "^0.13.5"
+                    }
+                },
+                "react-dom": {
+                    "version": "16.8.5",
+                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.5.tgz",
+                    "integrity": "sha512-VIEIvZLpFafsfu4kgmftP5L8j7P1f0YThfVTrANMhZUFMDOsA6e0kfR6wxw/8xxKs4NB59TZYbxNdPCDW34x4w==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "prop-types": "^15.6.2",
+                        "scheduler": "^0.13.5"
+                    }
+                },
+                "scheduler": {
+                    "version": "0.13.6",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+                    "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                },
+                "tslib": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+                    "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+                },
+                "whatwg-fetch": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+                    "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+                }
+            }
+        },
+        "@microsoft/sp-webpart-base": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.10.0.tgz",
+            "integrity": "sha512-zux7B9rQacyYQikEMJ/zXYudZzlGeZyLOhawodV4ejuRKZ7Y7AFxskEJxGpo+twpoN2PWeixxBvBsu2lFT1ePA==",
+            "requires": {
+                "@microsoft/decorators": "1.10.0",
+                "@microsoft/load-themed-styles": "1.10.20",
+                "@microsoft/sp-component-base": "1.10.0",
+                "@microsoft/sp-core-library": "1.10.0",
+                "@microsoft/sp-diagnostics": "1.10.0",
+                "@microsoft/sp-dynamic-data": "1.10.0",
+                "@microsoft/sp-http": "1.10.0",
+                "@microsoft/sp-loader": "1.10.0",
+                "@microsoft/sp-lodash-subset": "1.10.0",
+                "@microsoft/sp-module-interfaces": "1.10.0",
+                "@microsoft/sp-page-context": "1.10.0",
+                "@microsoft/sp-property-pane": "1.10.0",
+                "@microsoft/teams-js": "1.4.2",
+                "@types/es6-promise": "0.0.33",
+                "@types/office-js": "1.0.36",
                 "@types/webpack-env": "1.13.1",
-                "office-ui-fabric-react": "6.143.0",
+                "office-ui-fabric-react": "7.59.0",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
                 "@microsoft/load-themed-styles": {
-                    "version": "1.8.62",
-                    "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.62.tgz",
-                    "integrity": "sha512-T9yplfIBWV6R5n0y9TuAnF8og7lUTFRqiOD/F8y3J4ziAkg3RD2Gih7p0TdTD4vmqbFJOpuuXMNMpERFFMgvvg=="
+                    "version": "1.10.20",
+                    "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.20.tgz",
+                    "integrity": "sha512-auT1V9phsMScUQK/xVngVGQsABGG805/10RgP1TBbJvwoPoRq/Ed+ce47HoayFgqxtz5m/W/38OUNZpfuBqsCw=="
                 },
                 "tslib": {
                     "version": "1.9.3",
@@ -1836,9 +2069,9 @@
             }
         },
         "@microsoft/teams-js": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.4.1.tgz",
-            "integrity": "sha512-0BuWgUrZvZ0X98roHTWQVtnjlw22DWJBFW7LCqKS7Q/0Zu19GAWNL/mJoVJRRujVHUbEW+QU0qwJK6KqitUcsw=="
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.4.2.tgz",
+            "integrity": "sha512-O10tpakpm+NyClJOW4eCaidlDI5sW9b5oRGQiUA0WqFG6GQt1HEz/KFsCN+ebaFgjstx+trZzYIuYdpK98XsMQ=="
         },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
@@ -1990,22 +2223,33 @@
         "@types/node": {
             "version": "8.5.8",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/@types/node/-/node-8.5.8.tgz",
-            "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg=="
+            "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+            "dev": true
+        },
+        "@types/office-js": {
+            "version": "1.0.36",
+            "resolved": "https://registry.npmjs.org/@types/office-js/-/office-js-1.0.36.tgz",
+            "integrity": "sha512-v5jOXCPS0nbbuVzZThhDMzttuJrpzzvx1GsPo5Qed8Cs9uzMwEV1vdkKN5zLFnAUlEF4s8Szl9KXnhnSvH89Kw=="
+        },
+        "@types/prop-types": {
+            "version": "15.7.3",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
         },
         "@types/react": {
-            "version": "16.4.2",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.2.tgz",
-            "integrity": "sha512-oVcVteCDNiVc/fkDjowRfAZQDEOR76j3CJ3FvwXNvfV6zJguhghy1lMgpAzYox+9AZsWch+JPV6Imml3wvIUeg==",
+            "version": "16.8.8",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.8.tgz",
+            "integrity": "sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==",
             "requires": {
+                "@types/prop-types": "*",
                 "csstype": "^2.2.0"
             }
         },
         "@types/react-dom": {
-            "version": "16.0.5",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.5.tgz",
-            "integrity": "sha512-ony2hEYlGXCLWNAWWgbsHR7qVvDbeMRFc5b43+7dhj3n+zXzxz81HV9Yjpc3JD8vLCiwYoSLqFCI6bD0+0zG2Q==",
+            "version": "16.8.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.3.tgz",
+            "integrity": "sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==",
             "requires": {
-                "@types/node": "*",
                 "@types/react": "*"
             }
         },
@@ -2049,109 +2293,176 @@
             "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw="
         },
         "@uifabric/foundation": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-0.7.6.tgz",
-            "integrity": "sha512-3CGViA4aCjnCq3P+9S/HuuI44mGOgZVA9DDOhiht1JLk3z2NiXcmdGoEoJUj84Wck3yT0n34tD8AL1PreuFHMQ==",
+            "version": "7.5.23",
+            "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.5.23.tgz",
+            "integrity": "sha512-FIzJorSPmazXgiLauRufFnlhKd3W9X0x7iq5EbPHg8zwem6S87qzHn4IuXxBde9KE3LvAtflzlak+VNdXUsPdg==",
             "requires": {
-                "@uifabric/set-version": "^1.1.3",
-                "@uifabric/styling": "^6.47.6",
-                "@uifabric/utilities": "^6.38.3",
-                "tslib": "^1.7.1"
+                "@uifabric/merge-styles": "^7.8.10",
+                "@uifabric/set-version": "^7.0.9",
+                "@uifabric/styling": "^7.11.0",
+                "@uifabric/utilities": "^7.15.3",
+                "tslib": "^1.10.0"
             },
             "dependencies": {
-                "@uifabric/merge-styles": {
-                    "version": "6.17.4",
-                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.17.4.tgz",
-                    "integrity": "sha512-IYg+LiyetyqSadHTHYYUfpYKWdlKIF5LTmumMX2Mp0HtgAc51KOf2xx2XX6M35jERIGyBSvQruOXjvJXVGsXSg==",
-                    "requires": {
-                        "@uifabric/set-version": "^1.1.3",
-                        "tslib": "^1.7.1"
-                    }
-                },
-                "@uifabric/styling": {
-                    "version": "6.47.6",
-                    "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.47.6.tgz",
-                    "integrity": "sha512-nTsuwEbPTUofPFX3/RZ8FprRUTI02GsRffdNIxannHuVBntHAbKB0CrvQ2TfLX4CDFNM+8BA/5o/YLaeKtF43w==",
-                    "requires": {
-                        "@microsoft/load-themed-styles": "^1.7.13",
-                        "@uifabric/merge-styles": "^6.17.3",
-                        "@uifabric/set-version": "^1.1.3",
-                        "@uifabric/utilities": "^6.38.3",
-                        "tslib": "^1.7.1"
-                    }
-                },
                 "@uifabric/utilities": {
-                    "version": "6.39.2",
-                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.39.2.tgz",
-                    "integrity": "sha512-JSrqFtvlGt+ZoSc4ZNNNGvTN3CnSWrd+Hc0GZqUVDVryKHCDqODop8WxIW0qrD307VK2E/r/6M7oAvT6jRhmhA==",
+                    "version": "7.15.3",
+                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.3.tgz",
+                    "integrity": "sha512-VuVv5SHOaPrpT+fONDgnpd/871TXXfQWxCgn+fETVvhsHKskVK0MhnTbi3f6MhHJZQl2SyYCUKbnOCIWguu4eQ==",
                     "requires": {
-                        "@uifabric/merge-styles": "^6.17.4",
-                        "@uifabric/set-version": "^1.1.3",
-                        "prop-types": "^15.5.10",
-                        "tslib": "^1.7.1"
+                        "@uifabric/merge-styles": "^7.8.10",
+                        "@uifabric/set-version": "^7.0.9",
+                        "prop-types": "^15.7.2",
+                        "tslib": "^1.10.0"
                     }
+                },
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
                 }
             }
         },
         "@uifabric/icons": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.4.0.tgz",
-            "integrity": "sha512-pbKu3OnWaRIeDqMFhicDrrcqicxNqoHpJpknZR9N2xxoPnYMnt2ZOhBNnAxoVVcxHlWkFNg0rvFrOAQGn+S5/Q==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.3.0.tgz",
+            "integrity": "sha512-wbcR8fJce20sPjsK2bbTC/cAZfAOFuE4dd4LHw194+8H+/dqotsowrQVp5Lu8aaHGQk+fXoiZmUy30WA9cAG4Q==",
             "requires": {
-                "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                "@uifabric/styling": ">=6.41.0 <7.0.0",
+                "@uifabric/set-version": "^7.0.2",
+                "@uifabric/styling": "^7.7.1",
                 "tslib": "^1.7.1"
             }
         },
         "@uifabric/merge-styles": {
-            "version": "6.17.4",
-            "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.17.4.tgz",
-            "integrity": "sha512-IYg+LiyetyqSadHTHYYUfpYKWdlKIF5LTmumMX2Mp0HtgAc51KOf2xx2XX6M35jERIGyBSvQruOXjvJXVGsXSg==",
+            "version": "7.8.10",
+            "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.8.10.tgz",
+            "integrity": "sha512-VQ2GE6YVL9IGAgd7ZGpDMpwjNy4Ls4Wlb+ijugDRCK/DKgl2mX2iSUGV+fsWgiHAt8O1LQP5mvggtMPNOroSTw==",
             "requires": {
-                "@uifabric/set-version": "^1.1.3",
-                "tslib": "^1.7.1"
+                "@uifabric/set-version": "^7.0.9",
+                "tslib": "^1.10.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
+            }
+        },
+        "@uifabric/react-hooks": {
+            "version": "7.0.24",
+            "resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.0.24.tgz",
+            "integrity": "sha512-bvvJZ7CyJpzd5U7wASnL94p6yaPOeRbScIfUb6HZiBEX++8h6wfa3jXt1H3cTJh+ZVyFDy8XP+5PelA5UGkXng==",
+            "requires": {
+                "@uifabric/set-version": "^7.0.9",
+                "@uifabric/utilities": "^7.15.3",
+                "tslib": "^1.10.0"
+            },
+            "dependencies": {
+                "@uifabric/merge-styles": {
+                    "version": "7.8.10",
+                    "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.8.10.tgz",
+                    "integrity": "sha512-VQ2GE6YVL9IGAgd7ZGpDMpwjNy4Ls4Wlb+ijugDRCK/DKgl2mX2iSUGV+fsWgiHAt8O1LQP5mvggtMPNOroSTw==",
+                    "requires": {
+                        "@uifabric/set-version": "^7.0.9",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "@uifabric/set-version": {
+                    "version": "7.0.9",
+                    "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.9.tgz",
+                    "integrity": "sha512-YJL6WLBlFKDJcLSw1ihqW5PTFi2XMoluEvwGd2qtzp2IVbHvdbk7uIdWuTALo3dFNNqWPN8shSNUdHVATE/1jQ==",
+                    "requires": {
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "@uifabric/utilities": {
+                    "version": "7.15.3",
+                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.3.tgz",
+                    "integrity": "sha512-VuVv5SHOaPrpT+fONDgnpd/871TXXfQWxCgn+fETVvhsHKskVK0MhnTbi3f6MhHJZQl2SyYCUKbnOCIWguu4eQ==",
+                    "requires": {
+                        "@uifabric/merge-styles": "^7.8.10",
+                        "@uifabric/set-version": "^7.0.9",
+                        "prop-types": "^15.7.2",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "loose-envify": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                    "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                    "requires": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                    }
+                },
+                "prop-types": {
+                    "version": "15.7.2",
+                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+                    "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+                    "requires": {
+                        "loose-envify": "^1.4.0",
+                        "object-assign": "^4.1.1",
+                        "react-is": "^16.8.1"
+                    }
+                },
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
             }
         },
         "@uifabric/set-version": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-1.1.3.tgz",
-            "integrity": "sha512-IYpwVIuN7MJOeiWzZzr9AmFSvA5zc6gJn4fNHtEFIQnNB8WVWIcYrvx8Tbf7wWj9MvhdHYp70F054zZlHbL/Ag==",
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.9.tgz",
+            "integrity": "sha512-YJL6WLBlFKDJcLSw1ihqW5PTFi2XMoluEvwGd2qtzp2IVbHvdbk7uIdWuTALo3dFNNqWPN8shSNUdHVATE/1jQ==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "^1.10.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
             }
         },
         "@uifabric/styling": {
-            "version": "6.47.6",
-            "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.47.6.tgz",
-            "integrity": "sha512-nTsuwEbPTUofPFX3/RZ8FprRUTI02GsRffdNIxannHuVBntHAbKB0CrvQ2TfLX4CDFNM+8BA/5o/YLaeKtF43w==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.11.0.tgz",
+            "integrity": "sha512-H7o3uh6tIw63/8rCQJ9arLiA/lY87t3ENF2hmvnbPLSYmPp6Y+Hrql3ogGXTGrQX006OGelvnJRqshh3CrEI4w==",
             "requires": {
-                "@microsoft/load-themed-styles": "^1.7.13",
-                "@uifabric/merge-styles": "^6.17.3",
-                "@uifabric/set-version": "^1.1.3",
-                "@uifabric/utilities": "^6.38.3",
-                "tslib": "^1.7.1"
+                "@microsoft/load-themed-styles": "^1.10.26",
+                "@uifabric/merge-styles": "^7.8.10",
+                "@uifabric/set-version": "^7.0.9",
+                "@uifabric/utilities": "^7.15.3",
+                "tslib": "^1.10.0"
             },
             "dependencies": {
                 "@uifabric/utilities": {
-                    "version": "6.39.2",
-                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.39.2.tgz",
-                    "integrity": "sha512-JSrqFtvlGt+ZoSc4ZNNNGvTN3CnSWrd+Hc0GZqUVDVryKHCDqODop8WxIW0qrD307VK2E/r/6M7oAvT6jRhmhA==",
+                    "version": "7.15.3",
+                    "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.15.3.tgz",
+                    "integrity": "sha512-VuVv5SHOaPrpT+fONDgnpd/871TXXfQWxCgn+fETVvhsHKskVK0MhnTbi3f6MhHJZQl2SyYCUKbnOCIWguu4eQ==",
                     "requires": {
-                        "@uifabric/merge-styles": "^6.17.4",
-                        "@uifabric/set-version": "^1.1.3",
-                        "prop-types": "^15.5.10",
-                        "tslib": "^1.7.1"
+                        "@uifabric/merge-styles": "^7.8.10",
+                        "@uifabric/set-version": "^7.0.9",
+                        "prop-types": "^15.7.2",
+                        "tslib": "^1.10.0"
                     }
+                },
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
                 }
             }
         },
         "@uifabric/utilities": {
-            "version": "6.29.4",
-            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.29.4.tgz",
-            "integrity": "sha512-ESyMQfJrIGy1uM0HQApW0gvKpQCZBWLLoQTGZIq8Z4ZcTUEYN4Te+6oImtn0dxI1CIK6fbQNtLvZb5fX82+jMA==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.5.0.tgz",
+            "integrity": "sha512-h9XwZVaKyLN3Ss4G+bXFWsmCzExID/SKbO64XPjsCIhuxVYsTg6/hDrvyU4TCEx06/ehXfdHRmyjCYL1PNdDMg==",
             "requires": {
-                "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-                "@uifabric/set-version": ">=1.1.3 <2.0.0",
+                "@uifabric/merge-styles": "^7.7.0",
+                "@uifabric/set-version": "^7.0.2",
                 "prop-types": "^15.5.10",
                 "tslib": "^1.7.1"
             }
@@ -2781,6 +3092,11 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "big.js": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+        },
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/bluebird/-/bluebird-3.5.1.tgz",
@@ -3394,6 +3710,11 @@
                 }
             }
         },
+        "emojis-list": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        },
         "encoding": {
             "version": "0.1.12",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/encoding/-/encoding-0.1.12.tgz",
@@ -3574,6 +3895,15 @@
                     "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
                     "dev": true
                 }
+            }
+        },
+        "exports-loader": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.4.tgz",
+            "integrity": "sha1-1w/GEhl1s1/BKDDPUnVL4nQPyIY=",
+            "requires": {
+                "loader-utils": "^1.0.2",
+                "source-map": "0.5.x"
             }
         },
         "extend": {
@@ -6154,8 +6484,7 @@
         "json5": {
             "version": "0.5.1",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -6213,6 +6542,16 @@
             "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
+            }
+        },
+        "loader-utils": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+            "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+            "requires": {
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0"
             }
         },
         "lodash": {
@@ -6416,6 +6755,21 @@
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
+        },
+        "msal": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/msal/-/msal-1.1.3.tgz",
+            "integrity": "sha512-cdShb+N1H3OyR1y46ij6OO7QzeqC6BxrbrNcouS4JBrr1+DnZ55TumxQKEzWmTXHvsbsuz5PCyXZl812Un8L9g==",
+            "requires": {
+                "tslib": "^1.9.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+                    "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+                }
+            }
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -6631,17 +6985,18 @@
             }
         },
         "office-ui-fabric-react": {
-            "version": "6.143.0",
-            "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.143.0.tgz",
-            "integrity": "sha512-JXV1h8upR+WPYQ7SuJFgp9XuLrJUDT9QjI7bzbyY+dpwjKCX0D22BlTfi7O52IdDt4eFesJofN8DfW0A/opvMw==",
+            "version": "7.59.0",
+            "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.59.0.tgz",
+            "integrity": "sha512-bZg1Msffb7DKAawxzxmUYMEv+me6FzdPvRKbrG7pQrj/rRR8ofPbo43NRFfFmOdHnNs7290H0Cwpu3kRk+6msg==",
             "requires": {
                 "@microsoft/load-themed-styles": "^1.7.13",
-                "@uifabric/foundation": ">=0.7.1 <1.0.0",
-                "@uifabric/icons": ">=6.4.0 <7.0.0",
-                "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-                "@uifabric/set-version": ">=1.1.3 <2.0.0",
-                "@uifabric/styling": ">=6.41.0 <7.0.0",
-                "@uifabric/utilities": ">=6.29.3 <7.0.0",
+                "@uifabric/foundation": "^7.5.0",
+                "@uifabric/icons": "^7.3.0",
+                "@uifabric/merge-styles": "^7.8.0",
+                "@uifabric/react-hooks": "^7.0.1",
+                "@uifabric/set-version": "^7.0.2",
+                "@uifabric/styling": "^7.7.2",
+                "@uifabric/utilities": "^7.5.0",
                 "prop-types": "^15.5.10",
                 "tslib": "^1.7.1"
             }
@@ -6854,12 +7209,23 @@
             }
         },
         "prop-types": {
-            "version": "15.6.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/prop-types/-/prop-types-15.6.2.tgz",
-            "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
             "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            },
+            "dependencies": {
+                "loose-envify": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                    "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                    "requires": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                    }
+                }
             }
         },
         "proto-list": {
@@ -6902,33 +7268,37 @@
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
+        "raw-loader": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+            "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao="
+        },
         "react": {
-            "version": "16.7.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-            "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+            "version": "16.8.5",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.8.5.tgz",
+            "integrity": "sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2",
-                "scheduler": "^0.12.0"
+                "scheduler": "^0.13.5"
             }
         },
         "react-dom": {
-            "version": "16.7.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-            "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+            "version": "16.8.5",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.5.tgz",
+            "integrity": "sha512-VIEIvZLpFafsfu4kgmftP5L8j7P1f0YThfVTrANMhZUFMDOsA6e0kfR6wxw/8xxKs4NB59TZYbxNdPCDW34x4w==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2",
-                "scheduler": "^0.12.0"
+                "scheduler": "^0.13.5"
             }
         },
         "react-is": {
             "version": "16.8.6",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-            "dev": true
+            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
         },
         "readable-stream": {
             "version": "2.3.6",
@@ -7344,9 +7714,9 @@
             "dev": true
         },
         "scheduler": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-            "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+            "version": "0.13.6",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+            "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -7540,8 +7910,7 @@
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
             "version": "0.5.2",
@@ -7857,9 +8226,9 @@
             }
         },
         "tslib": {
-            "version": "1.8.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/tslib/-/tslib-1.8.1.tgz",
-            "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         },
         "tunnel-agent": {
             "version": "0.6.0",
@@ -7887,9 +8256,9 @@
             }
         },
         "typescript": {
-            "version": "3.4.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-            "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,46 +4,68 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@babel/core": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
-            "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+        "@babel/code-frame": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.4.4",
-                "@babel/helpers": "^7.4.4",
-                "@babel/parser": "^7.4.5",
-                "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.4.5",
-                "@babel/types": "^7.4.4",
-                "convert-source-map": "^1.1.0",
+                "@babel/highlight": "^7.8.3"
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
+            "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.9.1",
+                "invariant": "^2.2.4",
+                "semver": "^5.5.0"
+            }
+        },
+        "@babel/core": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+            "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.8.3",
+                "@babel/generator": "^7.9.0",
+                "@babel/helper-module-transforms": "^7.9.0",
+                "@babel/helpers": "^7.9.0",
+                "@babel/parser": "^7.9.0",
+                "@babel/template": "^7.8.6",
+                "@babel/traverse": "^7.9.0",
+                "@babel/types": "^7.9.0",
+                "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
-                "json5": "^2.1.0",
-                "lodash": "^4.17.11",
+                "gensync": "^1.0.0-beta.1",
+                "json5": "^2.1.2",
+                "lodash": "^4.17.13",
                 "resolve": "^1.3.2",
                 "semver": "^5.4.1",
                 "source-map": "^0.5.0"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-                    "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.0.0"
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
                     }
                 },
-                "@babel/highlight": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-                    "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+                "convert-source-map": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+                    "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
+                        "safe-buffer": "~5.1.1"
                     }
                 },
                 "debug": {
@@ -55,37 +77,31 @@
                         "ms": "^2.1.1"
                     }
                 },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
                 "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.0"
+                        "minimist": "^1.2.5"
                     }
                 },
                 "lodash": {
-                    "version": "4.17.11",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
                     "dev": true
                 },
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 },
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 },
                 "path-parse": {
@@ -95,135 +111,726 @@
                     "dev": true
                 },
                 "resolve": {
-                    "version": "1.11.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-                    "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+                    "version": "1.16.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
+                    "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
                     "dev": true,
                     "requires": {
                         "path-parse": "^1.0.6"
                     }
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
                 }
             }
         },
         "@babel/generator": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-            "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+            "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.4.4",
+                "@babel/types": "^7.9.5",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.11",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "lodash": "^4.17.13",
+                "source-map": "^0.5.0"
             },
             "dependencies": {
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
                 },
                 "lodash": {
-                    "version": "4.17.11",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+            "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+            "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.8.3",
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.8.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
+            "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.8.6",
+                "browserslist": "^4.9.1",
+                "invariant": "^2.2.4",
+                "levenary": "^1.1.1",
+                "semver": "^5.5.0"
+            }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
+            "integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.8.3",
+                "@babel/helper-regex": "^7.8.3",
+                "regexpu-core": "^4.7.0"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+            "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/types": "^7.8.3",
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+            "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
                     "dev": true
                 }
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+            "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/types": "^7.9.5"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+            "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+            "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+            "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+            "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+            "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-replace-supers": "^7.8.6",
+                "@babel/helper-simple-access": "^7.8.3",
+                "@babel/helper-split-export-declaration": "^7.8.3",
+                "@babel/template": "^7.8.6",
+                "@babel/types": "^7.9.0",
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+            "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+            "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
             "dev": true
         },
-        "@babel/helper-split-export-declaration": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-            "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+        "@babel/helper-regex": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+            "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.4.4"
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+            "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.8.3",
+                "@babel/helper-wrap-function": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.8.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+            "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.8.3",
+                "@babel/helper-optimise-call-expression": "^7.8.3",
+                "@babel/traverse": "^7.8.6",
+                "@babel/types": "^7.8.6"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+            "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.8.3",
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+            "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+            "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+            "dev": true
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+            "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/traverse": "^7.8.3",
+                "@babel/types": "^7.8.3"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
             }
         },
         "@babel/helpers": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-            "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+            "version": "7.9.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+            "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
-            }
-        },
-        "@babel/parser": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-            "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
-            "dev": true
-        },
-        "@babel/plugin-syntax-object-rest-spread": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
-            }
-        },
-        "@babel/template": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-            "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/template": "^7.8.3",
+                "@babel/traverse": "^7.9.0",
+                "@babel/types": "^7.9.0"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-                    "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.0.0"
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
                     }
                 },
-                "@babel/highlight": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-                    "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+            "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.9.0",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
                 "js-tokens": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -232,41 +839,731 @@
                 }
             }
         },
-        "@babel/traverse": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-            "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+        "@babel/parser": {
+            "version": "7.9.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+            "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+            "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+            "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.4.4",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.4.4",
-                "@babel/parser": "^7.4.5",
-                "@babel/types": "^7.4.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.11"
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-remap-async-to-generator": "^7.8.3",
+                "@babel/plugin-syntax-async-generators": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+            "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+            "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+            "integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
+            "integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-transform-parameters": "^7.9.5"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+            "integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.8.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
+            "integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.8.8",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.8.3.tgz",
+            "integrity": "sha512-UcAyQWg2bAN647Q+O811tG9MrJ38Z10jjhQdKNAL8fsyPzE3cCN/uT+f55cFVY4aGO4jqJAvmqsuY3GQDwAoXg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.8.3.tgz",
+            "integrity": "sha512-Zpg2Sgc++37kuFl6ppq2Q7Awc6E6AIW671x5PY8E/f7MCIyPPGK/EoeZXvvY3P42exZ3Q4/t3YOzP/HiN79jDg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+            "integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+            "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+            "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+            "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-remap-async-to-generator": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+            "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+            "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "lodash": "^4.17.13"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-                    "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
+            "integrity": "sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.8.3",
+                "@babel/helper-define-map": "^7.8.3",
+                "@babel/helper-function-name": "^7.9.5",
+                "@babel/helper-optimise-call-expression": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-replace-supers": "^7.8.6",
+                "@babel/helper-split-export-declaration": "^7.8.3",
+                "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+            "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
+            "integrity": "sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+            "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+            "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+            "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
+            "integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+            "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+            "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+            "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
+            "integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.9.0",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "babel-plugin-dynamic-import-node": "^2.3.0"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
+            "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.9.0",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-simple-access": "^7.8.3",
+                "babel-plugin-dynamic-import-node": "^2.3.0"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
+            "integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.8.3",
+                "@babel/helper-module-transforms": "^7.9.0",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "babel-plugin-dynamic-import-node": "^2.3.0"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
+            "integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.9.0",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+            "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+            "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+            "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-replace-supers": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
+            "integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+            "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.8.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
+            "integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.14.2"
+            }
+        },
+        "@babel/plugin-transform-reserved-words": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+            "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+            "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+            "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+            "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-regex": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+            "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+            "integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+            "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
+            "integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.9.0",
+                "@babel/helper-compilation-targets": "^7.8.7",
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+                "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+                "@babel/plugin-proposal-json-strings": "^7.8.3",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+                "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+                "@babel/plugin-syntax-async-generators": "^7.8.0",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+                "@babel/plugin-syntax-json-strings": "^7.8.0",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+                "@babel/plugin-syntax-top-level-await": "^7.8.3",
+                "@babel/plugin-transform-arrow-functions": "^7.8.3",
+                "@babel/plugin-transform-async-to-generator": "^7.8.3",
+                "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+                "@babel/plugin-transform-block-scoping": "^7.8.3",
+                "@babel/plugin-transform-classes": "^7.9.5",
+                "@babel/plugin-transform-computed-properties": "^7.8.3",
+                "@babel/plugin-transform-destructuring": "^7.9.5",
+                "@babel/plugin-transform-dotall-regex": "^7.8.3",
+                "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+                "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+                "@babel/plugin-transform-for-of": "^7.9.0",
+                "@babel/plugin-transform-function-name": "^7.8.3",
+                "@babel/plugin-transform-literals": "^7.8.3",
+                "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+                "@babel/plugin-transform-modules-amd": "^7.9.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+                "@babel/plugin-transform-modules-umd": "^7.9.0",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+                "@babel/plugin-transform-new-target": "^7.8.3",
+                "@babel/plugin-transform-object-super": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.9.5",
+                "@babel/plugin-transform-property-literals": "^7.8.3",
+                "@babel/plugin-transform-regenerator": "^7.8.7",
+                "@babel/plugin-transform-reserved-words": "^7.8.3",
+                "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+                "@babel/plugin-transform-spread": "^7.8.3",
+                "@babel/plugin-transform-sticky-regex": "^7.8.3",
+                "@babel/plugin-transform-template-literals": "^7.8.3",
+                "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+                "@babel/plugin-transform-unicode-regex": "^7.8.3",
+                "@babel/preset-modules": "^0.1.3",
+                "@babel/types": "^7.9.5",
+                "browserslist": "^4.9.1",
+                "core-js-compat": "^3.6.2",
+                "invariant": "^2.2.2",
+                "levenary": "^1.1.1",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.0.0"
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
                     }
                 },
-                "@babel/highlight": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-                    "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/preset-modules": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+            "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.9.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+            "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.13.5",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+                    "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/template": {
+            "version": "7.8.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+            "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.8.3",
+                "@babel/parser": "^7.8.6",
+                "@babel/types": "^7.8.6"
+            },
+            "dependencies": {
+                "@babel/parser": {
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.9.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+            "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.8.3",
+                "@babel/generator": "^7.9.5",
+                "@babel/helper-function-name": "^7.9.5",
+                "@babel/helper-split-export-declaration": "^7.8.3",
+                "@babel/parser": "^7.9.0",
+                "@babel/types": "^7.9.5",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/parser": {
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
                     }
                 },
                 "debug": {
@@ -284,22 +1581,22 @@
                     "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
                     "dev": true
                 },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
                 "lodash": {
-                    "version": "4.17.11",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
                     "dev": true
                 },
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
                     "dev": true
                 }
             }
@@ -329,6 +1626,12 @@
                 }
             }
         },
+        "@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true
+        },
         "@cnakazawa/watch": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -347,166 +1650,328 @@
                 }
             }
         },
-        "@jest/console": {
-            "version": "24.7.1",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
-            "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+        "@istanbuljs/load-nyc-config": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+            "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
             "dev": true,
             "requires": {
-                "@jest/source-map": "^24.3.0",
-                "chalk": "^2.0.1",
-                "slash": "^2.0.0"
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
             },
             "dependencies": {
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
                     "dev": true
                 }
             }
         },
-        "@jest/core": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
-            "integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+        "@istanbuljs/schema": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+            "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+            "dev": true
+        },
+        "@jest/console": {
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.3.0.tgz",
+            "integrity": "sha512-LvSDNqpmZIZyweFaEQ6wKY7CbexPitlsLHGJtcooNECo0An/w49rFhjCJzu6efeb6+a3ee946xss1Jcd9r03UQ==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/reporters": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-changed-files": "^24.8.0",
-                "jest-config": "^24.8.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve-dependencies": "^24.8.0",
-                "jest-runner": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-snapshot": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-validate": "^24.8.0",
-                "jest-watcher": "^24.8.0",
-                "micromatch": "^3.1.10",
-                "p-each-series": "^1.0.0",
-                "pirates": "^4.0.1",
-                "realpath-native": "^1.1.0",
-                "rimraf": "^2.5.4",
-                "strip-ansi": "^5.0.0"
+                "@jest/source-map": "^25.2.6",
+                "chalk": "^3.0.0",
+                "jest-util": "^25.3.0",
+                "slash": "^3.0.0"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/core": {
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-25.3.0.tgz",
+            "integrity": "sha512-+D5a/tFf6pA/Gqft2DLBp/yeSRgXhlJ+Wpst0X/ZkfTRP54qDR3C61VfHwaex+GzZBiTcE9vQeoZ2v5T10+Mqw==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^25.3.0",
+                "@jest/reporters": "^25.3.0",
+                "@jest/test-result": "^25.3.0",
+                "@jest/transform": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^3.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.3",
+                "jest-changed-files": "^25.3.0",
+                "jest-config": "^25.3.0",
+                "jest-haste-map": "^25.3.0",
+                "jest-message-util": "^25.3.0",
+                "jest-regex-util": "^25.2.6",
+                "jest-resolve": "^25.3.0",
+                "jest-resolve-dependencies": "^25.3.0",
+                "jest-runner": "^25.3.0",
+                "jest-runtime": "^25.3.0",
+                "jest-snapshot": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "jest-validate": "^25.3.0",
+                "jest-watcher": "^25.3.0",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^2.1.0",
+                "realpath-native": "^2.0.0",
+                "rimraf": "^3.0.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
                     }
                 }
             }
         },
         "@jest/environment": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
-            "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.3.0.tgz",
+            "integrity": "sha512-vgooqwJTHLLak4fE+TaCGeYP7Tz1Y3CKOsNxR1sE0V3nx3KRUHn3NUnt+wbcfd5yQWKZQKAfW6wqbuwQLrXo3g==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "jest-mock": "^24.8.0"
+                "@jest/fake-timers": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "jest-mock": "^25.3.0"
             }
         },
         "@jest/fake-timers": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
-            "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.3.0.tgz",
+            "integrity": "sha512-NHAj7WbsyR3qBJPpBwSwqaq2WluIvUQsyzpJTN7XDVk7VnlC/y1BAnaYZL3vbPIP8Nhm0Ae5DJe0KExr/SdMJQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-mock": "^24.8.0"
+                "@jest/types": "^25.3.0",
+                "jest-message-util": "^25.3.0",
+                "jest-mock": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "lolex": "^5.0.0"
             }
         },
         "@jest/reporters": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
-            "integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.3.0.tgz",
+            "integrity": "sha512-1u0ZBygs0C9DhdYgLCrRfZfNKQa+9+J7Uo+Z9z0RWLHzgsxhoG32lrmMOtUw48yR6bLNELdvzormwUqSk4H4Vg==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^25.3.0",
+                "@jest/test-result": "^25.3.0",
+                "@jest/transform": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "chalk": "^3.0.0",
+                "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
                 "glob": "^7.1.2",
-                "istanbul-lib-coverage": "^2.0.2",
-                "istanbul-lib-instrument": "^3.0.1",
-                "istanbul-lib-report": "^2.0.4",
-                "istanbul-lib-source-maps": "^3.0.1",
-                "istanbul-reports": "^2.1.1",
-                "jest-haste-map": "^24.8.0",
-                "jest-resolve": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-worker": "^24.6.0",
-                "node-notifier": "^5.2.1",
-                "slash": "^2.0.0",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "jest-haste-map": "^25.3.0",
+                "jest-resolve": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "jest-worker": "^25.2.6",
+                "node-notifier": "^6.0.0",
+                "slash": "^3.0.0",
                 "source-map": "^0.6.0",
-                "string-length": "^2.0.0"
+                "string-length": "^3.1.0",
+                "terminal-link": "^2.0.0",
+                "v8-to-istanbul": "^4.0.1"
             },
             "dependencies": {
-                "istanbul-lib-coverage": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-                    "dev": true
-                },
-                "istanbul-lib-instrument": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-                    "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@babel/generator": "^7.4.0",
-                        "@babel/parser": "^7.4.3",
-                        "@babel/template": "^7.4.0",
-                        "@babel/traverse": "^7.4.3",
-                        "@babel/types": "^7.4.0",
-                        "istanbul-lib-coverage": "^2.0.5",
-                        "semver": "^6.0.0"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "semver": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
-                    "integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
                 "source-map": {
@@ -514,30 +1979,33 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
         "@jest/source-map": {
-            "version": "24.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
-            "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.2.6.tgz",
+            "integrity": "sha512-VuIRZF8M2zxYFGTEhkNSvQkUKafQro4y+mwUxy5ewRqs5N/ynSFUODYp3fy1zCnbCMy1pz3k+u57uCqx8QRSQQ==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0",
-                "graceful-fs": "^4.1.15",
+                "graceful-fs": "^4.2.3",
                 "source-map": "^0.6.0"
             },
             "dependencies": {
-                "callsites": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-                    "dev": true
-                },
                 "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
                     "dev": true
                 },
                 "source-map": {
@@ -549,221 +2017,133 @@
             }
         },
         "@jest/test-result": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
-            "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.3.0.tgz",
+            "integrity": "sha512-mqrGuiiPXl1ap09Mydg4O782F3ouDQfsKqtQzIjitpwv3t1cHDwCto21jThw6WRRE+dKcWQvLG70GpyLJICfGw==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/types": "^24.8.0",
-                "@types/istanbul-lib-coverage": "^2.0.0"
+                "@jest/console": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
             }
         },
         "@jest/test-sequencer": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
-            "integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.3.0.tgz",
+            "integrity": "sha512-Xvns3xbji7JCvVcDGvqJ/pf4IpmohPODumoPEZJ0/VgC5gI4XaNVIBET2Dq5Czu6Gk3xFcmhtthh/MBOTljdNg==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^24.8.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-runner": "^24.8.0",
-                "jest-runtime": "^24.8.0"
+                "@jest/test-result": "^25.3.0",
+                "jest-haste-map": "^25.3.0",
+                "jest-runner": "^25.3.0",
+                "jest-runtime": "^25.3.0"
             }
         },
         "@jest/transform": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
-            "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.3.0.tgz",
+            "integrity": "sha512-W01p8kTDvvEX6kd0tJc7Y5VdYyFaKwNWy1HQz6Jqlhu48z/8Gxp+yFCDVj+H8Rc7ezl3Mg0hDaGuFVkmHOqirg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/types": "^24.8.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "chalk": "^2.0.1",
+                "@jest/types": "^25.3.0",
+                "babel-plugin-istanbul": "^6.0.0",
+                "chalk": "^3.0.0",
                 "convert-source-map": "^1.4.0",
                 "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.15",
-                "jest-haste-map": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-util": "^24.8.0",
-                "micromatch": "^3.1.10",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
+                "graceful-fs": "^4.2.3",
+                "jest-haste-map": "^25.3.0",
+                "jest-regex-util": "^25.2.6",
+                "jest-util": "^25.3.0",
+                "micromatch": "^4.0.2",
+                "pirates": "^4.0.1",
+                "realpath-native": "^2.0.0",
+                "slash": "^3.0.0",
                 "source-map": "^0.6.1",
-                "write-file-atomic": "2.4.1"
+                "write-file-atomic": "^3.0.0"
             },
             "dependencies": {
-                "babel-plugin-istanbul": {
-                    "version": "5.1.4",
-                    "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-                    "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "find-up": "^3.0.0",
-                        "istanbul-lib-instrument": "^3.3.0",
-                        "test-exclude": "^5.2.3"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "find-up": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
-                "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
                     "dev": true
                 },
-                "istanbul-lib-coverage": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-                    "dev": true
-                },
-                "istanbul-lib-instrument": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-                    "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/generator": "^7.4.0",
-                        "@babel/parser": "^7.4.3",
-                        "@babel/template": "^7.4.0",
-                        "@babel/traverse": "^7.4.3",
-                        "@babel/types": "^7.4.0",
-                        "istanbul-lib-coverage": "^2.0.5",
-                        "semver": "^6.0.0"
-                    }
-                },
-                "load-json-file": {
+                "has-flag": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "parse-json": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-                    "dev": true,
-                    "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
-                    }
-                },
-                "path-type": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-                    "dev": true,
-                    "requires": {
-                        "pify": "^3.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
                     "dev": true
                 },
-                "read-pkg": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^4.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^3.0.0"
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
                     }
-                },
-                "read-pkg-up": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-                    "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^3.0.0",
-                        "read-pkg": "^3.0.0"
-                    }
-                },
-                "require-main-filename": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
-                    "integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
-                    "dev": true
-                },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
@@ -771,40 +2151,100 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 },
-                "test-exclude": {
-                    "version": "5.2.3",
-                    "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-                    "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "glob": "^7.1.3",
-                        "minimatch": "^3.0.4",
-                        "read-pkg-up": "^4.0.0",
-                        "require-main-filename": "^2.0.0"
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
                     }
                 },
                 "write-file-atomic": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
-                    "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+                    "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
                         "imurmurhash": "^0.1.4",
-                        "signal-exit": "^3.0.2"
+                        "is-typedarray": "^1.0.0",
+                        "signal-exit": "^3.0.2",
+                        "typedarray-to-buffer": "^3.1.5"
                     }
                 }
             }
         },
         "@jest/types": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
-            "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.3.0.tgz",
+            "integrity": "sha512-UkaDNewdqXAmCDbN2GlUM6amDKS78eCqiw/UmF5nE0mmLTd6moJkiZJML/X52Ke3LH7Swhw883IRXq8o9nWjVw==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^12.0.9"
+                "@types/yargs": "^15.0.0",
+                "chalk": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "@microsoft/decorators": {
@@ -2089,15 +3529,24 @@
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
             "dev": true
         },
+        "@sinonjs/commons": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+            "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
         "@types/adal-angular": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@types/adal-angular/-/adal-angular-1.0.1.tgz",
             "integrity": "sha512-2sRGxJYrluhvIz8ae98i5k5woe9Fics4dMFHTcNfY2xAkj5QGZor+sfZzlgM58Fpw7Kklau9Gn6OhgJP25dKug=="
         },
         "@types/babel__core": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-            "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+            "version": "7.1.7",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+            "integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.1.0",
@@ -2108,9 +3557,9 @@
             }
         },
         "@types/babel__generator": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-            "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+            "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
@@ -2127,9 +3576,9 @@
             }
         },
         "@types/babel__traverse": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
-            "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.10.tgz",
+            "integrity": "sha512-74fNdUGrWsgIB/V9kTO5FGHPWYY6Eqn+3Z7L6Hc4e/BxjYV7puvBqp5HwsVYYfLm6iURYBNCx4Ut37OF9yitCw==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0"
@@ -2139,6 +3588,12 @@
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
             "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+            "dev": true
+        },
+        "@types/color-name": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
         "@types/es6-promise": {
@@ -2231,6 +3686,12 @@
             "resolved": "https://registry.npmjs.org/@types/office-js/-/office-js-1.0.36.tgz",
             "integrity": "sha512-v5jOXCPS0nbbuVzZThhDMzttuJrpzzvx1GsPo5Qed8Cs9uzMwEV1vdkKN5zLFnAUlEF4s8Szl9KXnhnSvH89Kw=="
         },
+        "@types/prettier": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+            "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+            "dev": true
+        },
         "@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -2282,9 +3743,18 @@
             "integrity": "sha512-oHyg0NssP2RCpCvE35hhbSqMJRsc5lSW+GFe+Vc65JL+kHII1VMYM+0KeV/z4utFuUqPoQRmq8KMMp7ba0dj6Q=="
         },
         "@types/yargs": {
-            "version": "12.0.12",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
-            "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+            "version": "15.0.4",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+            "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+            "dev": true,
+            "requires": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "@types/yargs-parser": {
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+            "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
             "dev": true
         },
         "@types/z-schema": {
@@ -2468,9 +3938,9 @@
             }
         },
         "abab": {
-            "version": "1.0.4",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/abab/-/abab-1.0.4.tgz",
-            "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+            "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
             "dev": true
         },
         "abbrev": {
@@ -2480,19 +3950,34 @@
             "dev": true
         },
         "acorn": {
-            "version": "5.7.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/acorn/-/acorn-5.7.1.tgz",
-            "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+            "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
             "dev": true
         },
         "acorn-globals": {
-            "version": "4.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/acorn-globals/-/acorn-globals-4.1.0.tgz",
-            "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+            "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.0"
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+                    "dev": true
+                }
             }
+        },
+        "acorn-walk": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+            "dev": true
         },
         "adal-angular": {
             "version": "1.0.16",
@@ -2500,22 +3985,25 @@
             "integrity": "sha1-4rwxvHEqr/ugU6pN1GvITrXSCQ8="
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+            "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ansi-escapes": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-            "dev": true
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+            "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+            "dev": true,
+            "requires": {
+                "type-fest": "^0.11.0"
+            }
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -2540,6 +4028,15 @@
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -2594,10 +4091,13 @@
             "dev": true
         },
         "asn1": {
-            "version": "0.2.3",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-            "dev": true
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
         },
         "assert-plus": {
             "version": "1.0.0",
@@ -2615,12 +4115,6 @@
             "version": "1.0.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-            "dev": true
-        },
-        "async-limiter": {
-            "version": "1.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
         },
         "asynckit": {
@@ -2642,9 +4136,9 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.7.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/aws4/-/aws4-1.7.0.tgz",
-            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
             "dev": true
         },
         "babel-code-frame": {
@@ -2694,207 +4188,75 @@
                 }
             }
         },
+        "babel-core": {
+            "version": "7.0.0-bridge.0",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+            "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+            "dev": true
+        },
         "babel-jest": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
-            "integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.3.0.tgz",
+            "integrity": "sha512-qiXeX1Cmw4JZ5yQ4H57WpkO0MZ61Qj+YnsVUwAMnDV5ls+yHon11XjarDdgP7H8lTmiEi6biiZA8y3Tmvx6pCg==",
             "dev": true,
             "requires": {
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "@types/babel__core": "^7.1.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "babel-preset-jest": "^24.6.0",
-                "chalk": "^2.4.2",
-                "slash": "^2.0.0"
+                "@jest/transform": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "@types/babel__core": "^7.1.7",
+                "babel-plugin-istanbul": "^6.0.0",
+                "babel-preset-jest": "^25.3.0",
+                "chalk": "^3.0.0",
+                "slash": "^3.0.0"
             },
             "dependencies": {
-                "babel-plugin-istanbul": {
-                    "version": "5.1.4",
-                    "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-                    "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "find-up": "^3.0.0",
-                        "istanbul-lib-instrument": "^3.3.0",
-                        "test-exclude": "^5.2.3"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "find-up": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
-                "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "color-name": "~1.1.4"
                     }
                 },
-                "istanbul-lib-coverage": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
-                "istanbul-lib-instrument": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-                    "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/generator": "^7.4.0",
-                        "@babel/parser": "^7.4.3",
-                        "@babel/template": "^7.4.0",
-                        "@babel/traverse": "^7.4.3",
-                        "@babel/types": "^7.4.0",
-                        "istanbul-lib-coverage": "^2.0.5",
-                        "semver": "^6.0.0"
-                    }
-                },
-                "load-json-file": {
+                "has-flag": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "parse-json": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
-                    }
-                },
-                "path-type": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-                    "dev": true,
-                    "requires": {
-                        "pify": "^3.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                },
-                "read-pkg": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-                    "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^4.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^3.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-                    "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^3.0.0",
-                        "read-pkg": "^3.0.0"
-                    }
-                },
-                "require-main-filename": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
-                    "integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
-                    "dev": true
-                },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-                    "dev": true
-                },
-                "test-exclude": {
-                    "version": "5.2.3",
-                    "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-                    "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3",
-                        "minimatch": "^3.0.4",
-                        "read-pkg-up": "^4.0.0",
-                        "require-main-filename": "^2.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -2908,10 +4270,32 @@
                 "babel-runtime": "^6.22.0"
             }
         },
+        "babel-plugin-dynamic-import-node": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+            "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+            "dev": true,
+            "requires": {
+                "object.assign": "^4.1.0"
+            }
+        },
+        "babel-plugin-istanbul": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+            "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-instrument": "^4.0.0",
+                "test-exclude": "^6.0.0"
+            }
+        },
         "babel-plugin-jest-hoist": {
-            "version": "24.6.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
-            "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.6.tgz",
+            "integrity": "sha512-qE2xjMathybYxjiGFJg0mLFrz0qNp83aNZycWDY/SuHiZNq+vQfRQtuINqyXyue1ELd8Rd+1OhFSLjms8msMbw==",
             "dev": true,
             "requires": {
                 "@types/babel__traverse": "^7.0.6"
@@ -2939,14 +4323,32 @@
                 "babel-types": "^6.24.1"
             }
         },
-        "babel-preset-jest": {
-            "version": "24.6.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
-            "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+        "babel-preset-current-node-syntax": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz",
+            "integrity": "sha512-u/8cS+dEiK1SFILbOC8/rUI3ml9lboKuuMvZ/4aQnQmhecQAgPw5ew066C1ObnEAUmlx7dv/s2z52psWEtLNiw==",
             "dev": true,
             "requires": {
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                "babel-plugin-jest-hoist": "^24.6.0"
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+            }
+        },
+        "babel-preset-jest": {
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.3.0.tgz",
+            "integrity": "sha512-tjdvLKNMwDI9r+QWz9sZUQGTq1dpoxjUqFUpEasAc7MOtHg9XuLT2fx0udFG+k1nvMV0WvHHVAN7VmCZ+1Zxbw==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-jest-hoist": "^25.2.6",
+                "babel-preset-current-node-syntax": "^0.1.2"
             }
         },
         "babel-runtime": {
@@ -2963,6 +4365,12 @@
                     "version": "2.5.7",
                     "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/core-js/-/core-js-2.5.7.tgz",
                     "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+                    "dev": true
+                },
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
                     "dev": true
                 }
             }
@@ -3087,7 +4495,6 @@
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -3143,9 +4550,9 @@
             }
         },
         "browser-process-hrtime": {
-            "version": "0.1.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-            "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
             "dev": true
         },
         "browser-resolve": {
@@ -3155,6 +4562,18 @@
             "dev": true,
             "requires": {
                 "resolve": "1.1.7"
+            }
+        },
+        "browserslist": {
+            "version": "4.11.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+            "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30001038",
+                "electron-to-chromium": "^1.3.390",
+                "node-releases": "^1.1.53",
+                "pkg-up": "^2.0.0"
             }
         },
         "bs-logger": {
@@ -3210,10 +4629,22 @@
             "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
             "dev": true
         },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
+        },
         "camelcase": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001042",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
+            "integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw==",
             "dev": true
         },
         "capture-exit": {
@@ -3242,6 +4673,12 @@
                 "supports-color": "^5.3.0"
             }
         },
+        "ci-info": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true
+        },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/class-utils/-/class-utils-0.3.6.tgz",
@@ -3266,14 +4703,14 @@
             }
         },
         "cliui": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
             }
         },
         "clone": {
@@ -3288,10 +4725,10 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+        "collect-v8-coverage": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+            "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
             "dev": true
         },
         "collection-visit": {
@@ -3320,9 +4757,9 @@
             "dev": true
         },
         "combined-stream": {
-            "version": "1.0.6",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/combined-stream/-/combined-stream-1.0.6.tgz",
-            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
@@ -3389,6 +4826,24 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
+        "core-js-compat": {
+            "version": "3.6.5",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
+            "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.8.5",
+                "semver": "7.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+                    "dev": true
+                }
+            }
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3444,6 +4899,49 @@
                 "nested-error-stacks": "^2.1.0"
             }
         },
+        "cross-spawn": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+            "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "dependencies": {
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "css": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
@@ -3465,18 +4963,26 @@
             }
         },
         "cssom": {
-            "version": "0.3.4",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/cssom/-/cssom-0.3.4.tgz",
-            "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
             "dev": true
         },
         "cssstyle": {
-            "version": "0.3.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/cssstyle/-/cssstyle-0.3.1.tgz",
-            "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
+            "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "~0.3.6"
+            },
+            "dependencies": {
+                "cssom": {
+                    "version": "0.3.8",
+                    "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                    "dev": true
+                }
             }
         },
         "csstype": {
@@ -3494,14 +5000,14 @@
             }
         },
         "data-urls": {
-            "version": "1.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/data-urls/-/data-urls-1.0.0.tgz",
-            "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+            "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
             "dev": true,
             "requires": {
-                "abab": "^1.0.4",
-                "whatwg-mimetype": "^2.0.0",
-                "whatwg-url": "^6.4.0"
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0"
             },
             "dependencies": {
                 "tr46": {
@@ -3520,9 +5026,9 @@
                     "dev": true
                 },
                 "whatwg-url": {
-                    "version": "6.5.0",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/whatwg-url/-/whatwg-url-6.5.0.tgz",
-                    "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
                     "dev": true,
                     "requires": {
                         "lodash.sortby": "^4.7.0",
@@ -3557,6 +5063,12 @@
             "version": "0.1.3",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
         },
         "define-properties": {
@@ -3622,15 +5134,15 @@
             "dev": true
         },
         "detect-newline": {
-            "version": "2.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/detect-newline/-/detect-newline-2.1.0.tgz",
-            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
         },
         "diff-sequences": {
-            "version": "24.3.0",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
-            "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+            "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
             "dev": true
         },
         "dir-glob": {
@@ -3677,13 +5189,13 @@
             }
         },
         "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
-            "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "editorconfig": {
@@ -3709,6 +5221,18 @@
                     }
                 }
             }
+        },
+        "electron-to-chromium": {
+            "version": "1.3.412",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.412.tgz",
+            "integrity": "sha512-4bVdSeJScR8fT7ERveLWbxemY5uXEHVseqMRyORosiKcTUSGtVwBkV8uLjXCqoFLeImA57Z9hbz3TOid01U4Hw==",
+            "dev": true
+        },
+        "emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "emojis-list": {
             "version": "2.1.0",
@@ -3741,31 +5265,6 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "es-abstract": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-            "dev": true,
-            "requires": {
-                "es-to-primitive": "^1.2.0",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "is-callable": "^1.1.4",
-                "is-regex": "^1.0.4",
-                "object-keys": "^1.0.12"
-            }
-        },
-        "es-to-primitive": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-            "dev": true,
-            "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-            }
-        },
         "es6-collections": {
             "version": "0.5.6",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/es6-collections/-/es6-collections-0.5.6.tgz",
@@ -3783,24 +5282,18 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.10.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/escodegen/-/escodegen-1.10.0.tgz",
-            "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+            "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
             "dev": true,
             "requires": {
-                "esprima": "^3.1.3",
+                "esprima": "^4.0.1",
                 "estraverse": "^4.2.0",
                 "esutils": "^2.0.2",
                 "optionator": "^0.8.1",
                 "source-map": "~0.6.1"
             },
             "dependencies": {
-                "esprima": {
-                    "version": "3.1.3",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/esprima/-/esprima-3.1.3.tgz",
-                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-                    "dev": true
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/source-map/-/source-map-0.6.1.tgz",
@@ -3810,10 +5303,16 @@
                 }
             }
         },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
         "estraverse": {
-            "version": "4.2.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true
         },
         "estree-walker": {
@@ -3833,6 +5332,53 @@
             "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
             "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
             "dev": true
+        },
+        "execa": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+            "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "p-finally": "^2.0.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+            },
+            "dependencies": {
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+                    "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                }
+            }
         },
         "exit": {
             "version": "0.1.2",
@@ -3876,23 +5422,42 @@
             }
         },
         "expect": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
-            "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-25.3.0.tgz",
+            "integrity": "sha512-buboTXML2h/L0Kh44Ys2Cx49mX20ISc5KDirkxIs3Q9AJv0kazweUAbukegr+nHDOvFRKmxdojjIHCjqAceYfg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "ansi-styles": "^3.2.0",
-                "jest-get-type": "^24.8.0",
-                "jest-matcher-utils": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-regex-util": "^24.3.0"
+                "@jest/types": "^25.3.0",
+                "ansi-styles": "^4.0.0",
+                "jest-get-type": "^25.2.6",
+                "jest-matcher-utils": "^25.3.0",
+                "jest-message-util": "^25.3.0",
+                "jest-regex-util": "^25.2.6"
             },
             "dependencies": {
-                "jest-get-type": {
-                    "version": "24.8.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-                    "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 }
             }
@@ -3907,9 +5472,9 @@
             }
         },
         "extend": {
-            "version": "3.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true
         },
         "extend-shallow": {
@@ -4020,9 +5585,9 @@
             "dev": true
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
             "dev": true
         },
         "fast-glob": {
@@ -4131,6 +5696,24 @@
                 "path-exists": "^3.0.0"
             }
         },
+        "find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "dependencies": {
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/for-in/-/for-in-1.0.2.tgz",
@@ -4144,13 +5727,13 @@
             "dev": true
         },
         "form-data": {
-            "version": "2.3.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/form-data/-/form-data-2.3.2.tgz",
-            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
+                "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
         },
@@ -4180,17 +5763,39 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+            "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+            "dev": true,
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
-        "get-caller-file": {
-            "version": "1.0.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+        "gensync": {
+            "version": "1.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+            "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
             "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+            "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
         },
         "get-value": {
             "version": "2.0.6",
@@ -4208,9 +5813,9 @@
             }
         },
         "glob": {
-            "version": "7.1.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -4287,27 +5892,8 @@
             "version": "1.3.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/growly/-/growly-1.3.0.tgz",
             "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-            "dev": true
-        },
-        "handlebars": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
             "dev": true,
-            "requires": {
-                "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
+            "optional": true
         },
         "har-schema": {
             "version": "2.0.0",
@@ -4316,22 +5902,13 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "^5.1.0",
+                "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
-            }
-        },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -4350,9 +5927,9 @@
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
             "dev": true
         },
         "has-value": {
@@ -4402,6 +5979,12 @@
                 "whatwg-encoding": "^1.0.1"
             }
         },
+        "html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/http-signature/-/http-signature-1.2.0.tgz",
@@ -4412,6 +5995,12 @@
                 "jsprim": "^1.2.2",
                 "sshpk": "^1.7.0"
             }
+        },
+        "human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "dev": true
         },
         "iconv-lite": {
             "version": "0.4.23",
@@ -4428,67 +6017,13 @@
             "dev": true
         },
         "import-local": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-            "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+            "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^3.0.0",
-                "resolve-cwd": "^2.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-                    "dev": true
-                },
-                "pkg-dir": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^3.0.0"
-                    }
-                }
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
             }
         },
         "imurmurhash": {
@@ -4528,6 +6063,12 @@
                 "loose-envify": "^1.0.0"
             }
         },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+            "dev": true
+        },
         "is-accessor-descriptor": {
             "version": "0.1.6",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -4558,11 +6099,14 @@
                 "builtin-modules": "^1.0.0"
             }
         },
-        "is-callable": {
-            "version": "1.1.4",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-            "dev": true
+        "is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^2.0.0"
+            }
         },
         "is-data-descriptor": {
             "version": "0.1.4",
@@ -4572,12 +6116,6 @@
             "requires": {
                 "kind-of": "^3.0.2"
             }
-        },
-        "is-date-object": {
-            "version": "1.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -4605,9 +6143,15 @@
             "dev": true
         },
         "is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true
+        },
+        "is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
         },
         "is-number": {
@@ -4634,28 +6178,10 @@
                 "isobject": "^3.0.1"
             }
         },
-        "is-regex": {
-            "version": "1.0.4",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/is-regex/-/is-regex-1.0.4.tgz",
-            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.1"
-            }
-        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "is-symbol": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-            "dev": true,
-            "requires": {
-                "has-symbols": "^1.0.0"
-            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -4676,10 +6202,11 @@
             "dev": true
         },
         "is-wsl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-            "dev": true
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+            "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+            "dev": true,
+            "optional": true
         },
         "isarray": {
             "version": "1.0.0",
@@ -4714,66 +6241,205 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
         },
-        "istanbul-lib-report": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+        "istanbul-lib-coverage": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+            "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+            "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "supports-color": "^6.1.0"
+                "@babel/core": "^7.7.5",
+                "@babel/parser": "^7.7.5",
+                "@babel/template": "^7.7.4",
+                "@babel/traverse": "^7.7.4",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
-                "istanbul-lib-coverage": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-                    "dev": true
-                },
-                "make-dir": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                "@babel/generator": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+                    "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
                     "dev": true,
                     "requires": {
-                        "pify": "^4.0.1",
-                        "semver": "^5.6.0"
+                        "@babel/types": "^7.9.5",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
                     }
                 },
-                "pify": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                "@babel/helper-function-name": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+                    "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.8.3",
+                        "@babel/template": "^7.8.3",
+                        "@babel/types": "^7.9.5"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.8.3"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.8.3",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.8.3"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.9.4",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+                    "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.8.6",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+                    "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.8.3",
+                        "@babel/parser": "^7.8.6",
+                        "@babel/types": "^7.8.6"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+                    "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.8.3",
+                        "@babel/generator": "^7.9.5",
+                        "@babel/helper-function-name": "^7.9.5",
+                        "@babel/helper-split-export-declaration": "^7.8.3",
+                        "@babel/parser": "^7.9.0",
+                        "@babel/types": "^7.9.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.9.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+                    "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.9.5",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "globals": {
+                    "version": "11.12.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 },
                 "semver": {
-                    "version": "5.7.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+            "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^3.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "make-dir": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+                    "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^6.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
         },
         "istanbul-lib-source-maps": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-            "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+            "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
             "dev": true,
             "requires": {
                 "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "rimraf": "^2.6.3",
+                "istanbul-lib-coverage": "^3.0.0",
                 "source-map": "^0.6.1"
             },
             "dependencies": {
@@ -4786,38 +6452,10 @@
                         "ms": "^2.1.1"
                     }
                 },
-                "istanbul-lib-coverage": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-                    "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-                    "dev": true
-                },
-                "make-dir": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-                    "dev": true,
-                    "requires": {
-                        "pify": "^4.0.1",
-                        "semver": "^5.6.0"
-                    }
-                },
                 "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                },
-                "pify": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "5.7.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 },
                 "source-map": {
@@ -4829,1076 +6467,775 @@
             }
         },
         "istanbul-reports": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-            "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+            "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.1.2"
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
             }
         },
         "jest": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
-            "integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-25.3.0.tgz",
+            "integrity": "sha512-iKd5ShQSHzFT5IL/6h5RZJhApgqXSoPxhp5HEi94v6OAw9QkF8T7X+liEU2eEHJ1eMFYTHmeWLrpBWulsDpaUg==",
             "dev": true,
             "requires": {
-                "import-local": "^2.0.0",
-                "jest-cli": "^24.8.0"
+                "@jest/core": "^25.3.0",
+                "import-local": "^3.0.2",
+                "jest-cli": "^25.3.0"
             },
             "dependencies": {
-                "ci-info": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-                    "dev": true
-                },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "execa": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^4.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
-                "find-up": {
+                "chalk": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
-                "get-stream": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "pump": "^3.0.0"
+                        "color-name": "~1.1.4"
                     }
                 },
-                "invert-kv": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
-                "is-ci": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-                    "dev": true,
-                    "requires": {
-                        "ci-info": "^2.0.0"
-                    }
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
                 },
                 "jest-cli": {
-                    "version": "24.8.0",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
-                    "integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
+                    "version": "25.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.3.0.tgz",
+                    "integrity": "sha512-XpNQPlW1tzpP7RGG8dxpkRegYDuLjzSiENu92+CYM87nEbmEPb3b4+yo8xcsHOnj0AG7DUt9b3uG8LuHI3MDzw==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "^24.8.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "chalk": "^2.0.1",
+                        "@jest/core": "^25.3.0",
+                        "@jest/test-result": "^25.3.0",
+                        "@jest/types": "^25.3.0",
+                        "chalk": "^3.0.0",
                         "exit": "^0.1.2",
-                        "import-local": "^2.0.0",
+                        "import-local": "^3.0.2",
                         "is-ci": "^2.0.0",
-                        "jest-config": "^24.8.0",
-                        "jest-util": "^24.8.0",
-                        "jest-validate": "^24.8.0",
+                        "jest-config": "^25.3.0",
+                        "jest-util": "^25.3.0",
+                        "jest-validate": "^25.3.0",
                         "prompts": "^2.0.1",
-                        "realpath-native": "^1.1.0",
-                        "yargs": "^12.0.2"
+                        "realpath-native": "^2.0.0",
+                        "yargs": "^15.3.1"
                     }
                 },
-                "lcid": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^2.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "mem": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-                    "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-                    "dev": true,
-                    "requires": {
-                        "map-age-cleaner": "^0.1.1",
-                        "mimic-fn": "^2.0.0",
-                        "p-is-promise": "^2.0.0"
-                    }
-                },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
-                },
-                "os-locale": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-                    "dev": true,
-                    "requires": {
-                        "execa": "^1.0.0",
-                        "lcid": "^2.0.0",
-                        "mem": "^4.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "12.0.5",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.2.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^3.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1 || ^4.0.0",
-                        "yargs-parser": "^11.1.1"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "11.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
         },
         "jest-changed-files": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
-            "integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.3.0.tgz",
+            "integrity": "sha512-eqd5hyLbUjIVvLlJ3vQ/MoPxsxfESVXG9gvU19XXjKzxr+dXmZIqCXiY0OiYaibwlHZBJl2Vebkc0ADEMzCXew==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "execa": "^1.0.0",
-                "throat": "^4.0.0"
-            },
-            "dependencies": {
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "execa": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^4.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
-                "get-stream": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-                    "dev": true,
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                }
+                "@jest/types": "^25.3.0",
+                "execa": "^3.2.0",
+                "throat": "^5.0.0"
             }
         },
         "jest-config": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
-            "integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.3.0.tgz",
+            "integrity": "sha512-CmF1JnNWFmoCSPC4tnU52wnVBpuxHjilA40qH/03IHxIevkjUInSMwaDeE6ACfxMPTLidBGBCO3EbxvzPbo8wA==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "babel-jest": "^24.8.0",
-                "chalk": "^2.0.1",
+                "@jest/test-sequencer": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "babel-jest": "^25.3.0",
+                "chalk": "^3.0.0",
+                "deepmerge": "^4.2.2",
                 "glob": "^7.1.1",
-                "jest-environment-jsdom": "^24.8.0",
-                "jest-environment-node": "^24.8.0",
-                "jest-get-type": "^24.8.0",
-                "jest-jasmine2": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-validate": "^24.8.0",
-                "micromatch": "^3.1.10",
-                "pretty-format": "^24.8.0",
-                "realpath-native": "^1.1.0"
+                "jest-environment-jsdom": "^25.3.0",
+                "jest-environment-node": "^25.3.0",
+                "jest-get-type": "^25.2.6",
+                "jest-jasmine2": "^25.3.0",
+                "jest-regex-util": "^25.2.6",
+                "jest-resolve": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "jest-validate": "^25.3.0",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^25.3.0",
+                "realpath-native": "^2.0.0"
             },
             "dependencies": {
-                "jest-get-type": {
-                    "version": "24.8.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-                    "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
                 }
             }
         },
         "jest-diff": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
-            "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.3.0.tgz",
+            "integrity": "sha512-vyvs6RPoVdiwARwY4kqFWd4PirPLm2dmmkNzKqo38uZOzJvLee87yzDjIZLmY1SjM3XR5DwsUH+cdQ12vgqi1w==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "diff-sequences": "^24.3.0",
-                "jest-get-type": "^24.8.0",
-                "pretty-format": "^24.8.0"
+                "chalk": "^3.0.0",
+                "diff-sequences": "^25.2.6",
+                "jest-get-type": "^25.2.6",
+                "pretty-format": "^25.3.0"
             },
             "dependencies": {
-                "jest-get-type": {
-                    "version": "24.8.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-                    "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
         "jest-docblock": {
-            "version": "24.3.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
-            "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
+            "integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
             "dev": true,
             "requires": {
-                "detect-newline": "^2.1.0"
+                "detect-newline": "^3.0.0"
             }
         },
         "jest-each": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
-            "integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.3.0.tgz",
+            "integrity": "sha512-aBfS4VOf/Qs95yUlX6d6WBv0szvOcTkTTyCIaLuQGj4bSHsT+Wd9dDngVHrCe5uytxpN8VM+NAloI6nbPjXfXw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "pretty-format": "^24.8.0"
+                "@jest/types": "^25.3.0",
+                "chalk": "^3.0.0",
+                "jest-get-type": "^25.2.6",
+                "jest-util": "^25.3.0",
+                "pretty-format": "^25.3.0"
             },
             "dependencies": {
-                "jest-get-type": {
-                    "version": "24.8.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-                    "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
         "jest-environment-jsdom": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
-            "integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.3.0.tgz",
+            "integrity": "sha512-jdE4bQN+k2QEZ9sWOxsqDJvMzbdFSCN/4tw8X0TQaCqyzKz58PyEf41oIr4WO7ERdp7WaJGBSUKF7imR3UW1lg==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.8.0",
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "jest-mock": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jsdom": "^11.5.1"
+                "@jest/environment": "^25.3.0",
+                "@jest/fake-timers": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "jest-mock": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "jsdom": "^15.2.1"
             }
         },
         "jest-environment-node": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
-            "integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.3.0.tgz",
+            "integrity": "sha512-XO09S29Nx1NU7TiMPHMoDIkxoGBuKSTbE+sHp0gXbeLDXhIdhysUI25kOqFFSD9AuDgvPvxWCXrvNqiFsOH33g==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.8.0",
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "jest-mock": "^24.8.0",
-                "jest-util": "^24.8.0"
-            }
-        },
-        "jest-haste-map": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
-            "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
-            "dev": true,
-            "requires": {
-                "@jest/types": "^24.8.0",
-                "anymatch": "^2.0.0",
-                "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.7",
-                "graceful-fs": "^4.1.15",
-                "invariant": "^2.2.4",
-                "jest-serializer": "^24.4.0",
-                "jest-util": "^24.8.0",
-                "jest-worker": "^24.6.0",
-                "micromatch": "^3.1.10",
-                "sane": "^4.0.3",
-                "walker": "^1.0.7"
+                "@jest/environment": "^25.3.0",
+                "@jest/fake-timers": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "jest-mock": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
-                "fsevents": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-                    "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "jest-get-type": {
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+            "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.3.0.tgz",
+            "integrity": "sha512-LjXaRa+F8wwtSxo9G+hHD/Cp63PPQzvaBL9XCVoJD2rrcJO0Zr2+YYzAFWWYJ5GlPUkoaJFJtOuk0sL6MJY80A==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^25.3.0",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
+                "graceful-fs": "^4.2.3",
+                "jest-serializer": "^25.2.6",
+                "jest-util": "^25.3.0",
+                "jest-worker": "^25.2.6",
+                "micromatch": "^4.0.2",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7",
+                "which": "^2.0.2"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
-                        "nan": "^2.12.1",
-                        "node-pre-gyp": "^0.12.0"
-                    },
-                    "dependencies": {
-                        "abbrev": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "ansi-regex": {
-                            "version": "2.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "aproba": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "are-we-there-yet": {
-                            "version": "1.1.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "delegates": "^1.0.0",
-                                "readable-stream": "^2.0.6"
-                            }
-                        },
-                        "balanced-match": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "brace-expansion": {
-                            "version": "1.1.11",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "balanced-match": "^1.0.0",
-                                "concat-map": "0.0.1"
-                            }
-                        },
-                        "chownr": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "code-point-at": {
-                            "version": "1.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "concat-map": {
-                            "version": "0.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "console-control-strings": {
-                            "version": "1.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "core-util-is": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "debug": {
-                            "version": "4.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "ms": "^2.1.1"
-                            }
-                        },
-                        "deep-extend": {
-                            "version": "0.6.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "delegates": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "detect-libc": {
-                            "version": "1.0.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "fs-minipass": {
-                            "version": "1.2.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minipass": "^2.2.1"
-                            }
-                        },
-                        "fs.realpath": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "gauge": {
-                            "version": "2.7.4",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "aproba": "^1.0.3",
-                                "console-control-strings": "^1.0.0",
-                                "has-unicode": "^2.0.0",
-                                "object-assign": "^4.1.0",
-                                "signal-exit": "^3.0.0",
-                                "string-width": "^1.0.1",
-                                "strip-ansi": "^3.0.1",
-                                "wide-align": "^1.1.0"
-                            }
-                        },
-                        "glob": {
-                            "version": "7.1.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
-                            }
-                        },
-                        "has-unicode": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "iconv-lite": {
-                            "version": "0.4.24",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "safer-buffer": ">= 2.1.2 < 3"
-                            }
-                        },
-                        "ignore-walk": {
-                            "version": "3.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minimatch": "^3.0.4"
-                            }
-                        },
-                        "inflight": {
-                            "version": "1.0.6",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "once": "^1.3.0",
-                                "wrappy": "1"
-                            }
-                        },
-                        "inherits": {
-                            "version": "2.0.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "ini": {
-                            "version": "1.3.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "is-fullwidth-code-point": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "number-is-nan": "^1.0.0"
-                            }
-                        },
-                        "isarray": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "minimatch": {
-                            "version": "3.0.4",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "brace-expansion": "^1.1.7"
-                            }
-                        },
-                        "minimist": {
-                            "version": "0.0.8",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "minipass": {
-                            "version": "2.3.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.0"
-                            }
-                        },
-                        "minizlib": {
-                            "version": "1.2.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minipass": "^2.2.1"
-                            }
-                        },
-                        "mkdirp": {
-                            "version": "0.5.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "minimist": "0.0.8"
-                            }
-                        },
-                        "ms": {
-                            "version": "2.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "needle": {
-                            "version": "2.3.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "debug": "^4.1.0",
-                                "iconv-lite": "^0.4.4",
-                                "sax": "^1.2.4"
-                            }
-                        },
-                        "node-pre-gyp": {
-                            "version": "0.12.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "detect-libc": "^1.0.2",
-                                "mkdirp": "^0.5.1",
-                                "needle": "^2.2.1",
-                                "nopt": "^4.0.1",
-                                "npm-packlist": "^1.1.6",
-                                "npmlog": "^4.0.2",
-                                "rc": "^1.2.7",
-                                "rimraf": "^2.6.1",
-                                "semver": "^5.3.0",
-                                "tar": "^4"
-                            }
-                        },
-                        "nopt": {
-                            "version": "4.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "abbrev": "1",
-                                "osenv": "^0.1.4"
-                            }
-                        },
-                        "npm-bundled": {
-                            "version": "1.0.6",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "npm-packlist": {
-                            "version": "1.4.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "ignore-walk": "^3.0.1",
-                                "npm-bundled": "^1.0.1"
-                            }
-                        },
-                        "npmlog": {
-                            "version": "4.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "are-we-there-yet": "~1.1.2",
-                                "console-control-strings": "~1.1.0",
-                                "gauge": "~2.7.3",
-                                "set-blocking": "~2.0.0"
-                            }
-                        },
-                        "number-is-nan": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "object-assign": {
-                            "version": "4.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "once": {
-                            "version": "1.4.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "wrappy": "1"
-                            }
-                        },
-                        "os-homedir": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "os-tmpdir": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "osenv": {
-                            "version": "0.1.5",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "os-homedir": "^1.0.0",
-                                "os-tmpdir": "^1.0.0"
-                            }
-                        },
-                        "path-is-absolute": {
-                            "version": "1.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "process-nextick-args": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "rc": {
-                            "version": "1.2.8",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "deep-extend": "^0.6.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
-                            },
-                            "dependencies": {
-                                "minimist": {
-                                    "version": "1.2.0",
-                                    "bundled": true,
-                                    "dev": true,
-                                    "optional": true
-                                }
-                            }
-                        },
-                        "readable-stream": {
-                            "version": "2.3.6",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
-                            }
-                        },
-                        "rimraf": {
-                            "version": "2.6.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "glob": "^7.1.3"
-                            }
-                        },
-                        "safe-buffer": {
-                            "version": "5.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "safer-buffer": {
-                            "version": "2.1.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "sax": {
-                            "version": "1.2.4",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "semver": {
-                            "version": "5.7.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "set-blocking": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "signal-exit": {
-                            "version": "3.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "string-width": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
-                            }
-                        },
-                        "string_decoder": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "safe-buffer": "~5.1.0"
-                            }
-                        },
-                        "strip-ansi": {
-                            "version": "3.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "ansi-regex": "^2.0.0"
-                            }
-                        },
-                        "strip-json-comments": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "tar": {
-                            "version": "4.4.8",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "chownr": "^1.1.1",
-                                "fs-minipass": "^1.2.5",
-                                "minipass": "^2.3.4",
-                                "minizlib": "^1.1.1",
-                                "mkdirp": "^0.5.0",
-                                "safe-buffer": "^5.1.2",
-                                "yallist": "^3.0.2"
-                            }
-                        },
-                        "util-deprecate": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "wide-align": {
-                            "version": "1.1.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "string-width": "^1.0.2 || 2"
-                            }
-                        },
-                        "wrappy": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
-                        "yallist": {
-                            "version": "3.0.3",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
                     "dev": true
                 },
-                "nan": {
-                    "version": "2.14.0",
-                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-                    "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
                     "dev": true,
-                    "optional": true
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
                 }
             }
         },
         "jest-jasmine2": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
-            "integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.3.0.tgz",
+            "integrity": "sha512-NCYOGE6+HNzYFSui52SefgpsnIzvxjn6KAgqw66BdRp37xpMD/4kujDHLNW5bS5i53os5TcMn6jYrzQRO8VPrQ==",
             "dev": true,
             "requires": {
                 "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
+                "@jest/environment": "^25.3.0",
+                "@jest/source-map": "^25.2.6",
+                "@jest/test-result": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "chalk": "^3.0.0",
                 "co": "^4.6.0",
-                "expect": "^24.8.0",
+                "expect": "^25.3.0",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^24.8.0",
-                "jest-matcher-utils": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-snapshot": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "pretty-format": "^24.8.0",
-                "throat": "^4.0.0"
+                "jest-each": "^25.3.0",
+                "jest-matcher-utils": "^25.3.0",
+                "jest-message-util": "^25.3.0",
+                "jest-runtime": "^25.3.0",
+                "jest-snapshot": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "pretty-format": "^25.3.0",
+                "throat": "^5.0.0"
             },
             "dependencies": {
-                "is-generator-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-                    "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
         "jest-leak-detector": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
-            "integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.3.0.tgz",
+            "integrity": "sha512-jk7k24dMIfk8LUSQQGN8PyOy9+J0NAfHZWiDmUDYVMctY8FLJQ1eQ8+PjMoN8PgwhLIggUqgYJnyRFvUz3jLRw==",
             "dev": true,
             "requires": {
-                "pretty-format": "^24.8.0"
+                "jest-get-type": "^25.2.6",
+                "pretty-format": "^25.3.0"
             }
         },
         "jest-matcher-utils": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
-            "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.3.0.tgz",
+            "integrity": "sha512-ZBUJ2fchNIZt+fyzkuCFBb8SKaU//Rln45augfUtbHaGyVxCO++ANARdBK9oPGXU3hEDgyy7UHnOP/qNOJXFUg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "jest-diff": "^24.8.0",
-                "jest-get-type": "^24.8.0",
-                "pretty-format": "^24.8.0"
+                "chalk": "^3.0.0",
+                "jest-diff": "^25.3.0",
+                "jest-get-type": "^25.2.6",
+                "pretty-format": "^25.3.0"
             },
             "dependencies": {
-                "jest-get-type": {
-                    "version": "24.8.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-                    "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
         "jest-message-util": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
-            "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.3.0.tgz",
+            "integrity": "sha512-5QNy9Id4WxJbRITEbA1T1kem9bk7y2fD0updZMSTNHtbEDnYOGLDPAuFBhFgVmOZpv0n6OMdVkK+WhyXEPCcOw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
+                "@jest/types": "^25.3.0",
                 "@types/stack-utils": "^1.0.1",
-                "chalk": "^2.0.1",
-                "micromatch": "^3.1.10",
-                "slash": "^2.0.0",
+                "chalk": "^3.0.0",
+                "micromatch": "^4.0.2",
+                "slash": "^3.0.0",
                 "stack-utils": "^1.0.1"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-                    "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@babel/highlight": "^7.0.0"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "@babel/highlight": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-                    "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
+                        "fill-range": "^7.0.1"
                     }
                 },
-                "js-tokens": {
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "has-flag": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
                     "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
                 }
             }
         },
         "jest-mock": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
-            "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.3.0.tgz",
+            "integrity": "sha512-yRn6GbuqB4j3aYu+Z1ezwRiZfp0o9om5uOcBovVtkcRLeBCNP5mT0ysdenUsxAHnQUgGwPOE1wwhtQYe6NKirQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0"
+                "@jest/types": "^25.3.0"
             }
         },
         "jest-pnp-resolver": {
@@ -5908,313 +7245,289 @@
             "dev": true
         },
         "jest-regex-util": {
-            "version": "24.3.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
-            "integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+            "integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
             "dev": true
         },
         "jest-resolve": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
-            "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.3.0.tgz",
+            "integrity": "sha512-IHoQAAybulsJ+ZgWis+ekYKDAoFkVH5Nx/znpb41zRtpxj4fr2WNV9iDqavdSm8GIpMlsfZxbC/fV9DhW0q9VQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
+                "@jest/types": "^25.3.0",
                 "browser-resolve": "^1.11.3",
-                "chalk": "^2.0.1",
+                "chalk": "^3.0.0",
                 "jest-pnp-resolver": "^1.2.1",
-                "realpath-native": "^1.1.0"
+                "realpath-native": "^2.0.0",
+                "resolve": "^1.15.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+                    "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.16.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
+                    "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "jest-resolve-dependencies": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
-            "integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.3.0.tgz",
+            "integrity": "sha512-bDUlLYmHW+f7J7KgcY2lkq8EMRqKonRl0XoD4Wp5SJkgAxKJnsaIOlrrVNTfXYf+YOu3VCjm/Ac2hPF2nfsCIA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-snapshot": "^24.8.0"
+                "@jest/types": "^25.3.0",
+                "jest-regex-util": "^25.2.6",
+                "jest-snapshot": "^25.3.0"
             }
         },
         "jest-runner": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
-            "integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.3.0.tgz",
+            "integrity": "sha512-csDqSC9qGHYWDrzrElzEgFbteztFeZJmKhSgY5jlCIcN0+PhActzRNku0DA1Xa1HxGOb0/AfbP1EGJlP4fGPtA==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.4.2",
+                "@jest/console": "^25.3.0",
+                "@jest/environment": "^25.3.0",
+                "@jest/test-result": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "chalk": "^3.0.0",
                 "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.8.0",
-                "jest-docblock": "^24.3.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-jasmine2": "^24.8.0",
-                "jest-leak-detector": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-resolve": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-worker": "^24.6.0",
+                "graceful-fs": "^4.2.3",
+                "jest-config": "^25.3.0",
+                "jest-docblock": "^25.3.0",
+                "jest-haste-map": "^25.3.0",
+                "jest-jasmine2": "^25.3.0",
+                "jest-leak-detector": "^25.3.0",
+                "jest-message-util": "^25.3.0",
+                "jest-resolve": "^25.3.0",
+                "jest-runtime": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "jest-worker": "^25.2.6",
                 "source-map-support": "^0.5.6",
-                "throat": "^4.0.0"
+                "throat": "^5.0.0"
             },
             "dependencies": {
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "source-map-support": {
-                    "version": "0.5.12",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-                    "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
         },
         "jest-runtime": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
-            "integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.3.0.tgz",
+            "integrity": "sha512-gn5KYB1wxXRM3nfw8fVpthFu60vxQUCr+ShGq41+ZBFF3DRHZRKj3HDWVAVB4iTNBj2y04QeAo5cZ/boYaPg0w==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.8.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "@types/yargs": "^12.0.2",
-                "chalk": "^2.0.1",
+                "@jest/console": "^25.3.0",
+                "@jest/environment": "^25.3.0",
+                "@jest/source-map": "^25.2.6",
+                "@jest/test-result": "^25.3.0",
+                "@jest/transform": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^3.0.0",
+                "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
                 "glob": "^7.1.3",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.8.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-mock": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.8.0",
-                "jest-snapshot": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-validate": "^24.8.0",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "strip-bom": "^3.0.0",
-                "yargs": "^12.0.2"
+                "graceful-fs": "^4.2.3",
+                "jest-config": "^25.3.0",
+                "jest-haste-map": "^25.3.0",
+                "jest-message-util": "^25.3.0",
+                "jest-mock": "^25.3.0",
+                "jest-regex-util": "^25.2.6",
+                "jest-resolve": "^25.3.0",
+                "jest-snapshot": "^25.3.0",
+                "jest-util": "^25.3.0",
+                "jest-validate": "^25.3.0",
+                "realpath-native": "^2.0.0",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0",
+                "yargs": "^15.3.1"
             },
             "dependencies": {
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "execa": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-                    "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^6.0.0",
-                        "get-stream": "^4.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
-                "find-up": {
+                "chalk": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
-                "get-stream": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "pump": "^3.0.0"
+                        "color-name": "~1.1.4"
                     }
                 },
-                "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 },
                 "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
                     "dev": true
                 },
-                "invert-kv": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "lcid": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-                    "dev": true,
-                    "requires": {
-                        "invert-kv": "^2.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "mem": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-                    "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-                    "dev": true,
-                    "requires": {
-                        "map-age-cleaner": "^0.1.1",
-                        "mimic-fn": "^2.0.0",
-                        "p-is-promise": "^2.0.0"
-                    }
-                },
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                "strip-bom": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+                    "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
                     "dev": true
                 },
-                "os-locale": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-                    "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "execa": "^1.0.0",
-                        "lcid": "^2.0.0",
-                        "mem": "^4.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-                    "dev": true
-                },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "12.0.5",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.2.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^3.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1 || ^4.0.0",
-                        "yargs-parser": "^11.1.1"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "11.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
         },
         "jest-serializer": {
-            "version": "24.4.0",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
-            "integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.6.tgz",
+            "integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ==",
             "dev": true
         },
         "jest-serializer-vue": {
@@ -6227,23 +7540,92 @@
             }
         },
         "jest-snapshot": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
-            "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.3.0.tgz",
+            "integrity": "sha512-GGpR6Oro2htJPKh5RX4PR1xwo5jCEjtvSPLW1IS7N85y+2bWKbiknHpJJRKSdGXghElb5hWaeQASJI4IiRayGg==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
-                "expect": "^24.8.0",
-                "jest-diff": "^24.8.0",
-                "jest-matcher-utils": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-resolve": "^24.8.0",
-                "mkdirp": "^0.5.1",
+                "@jest/types": "^25.3.0",
+                "@types/prettier": "^1.19.0",
+                "chalk": "^3.0.0",
+                "expect": "^25.3.0",
+                "jest-diff": "^25.3.0",
+                "jest-get-type": "^25.2.6",
+                "jest-matcher-utils": "^25.3.0",
+                "jest-message-util": "^25.3.0",
+                "jest-resolve": "^25.3.0",
+                "make-dir": "^3.0.0",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^24.8.0",
-                "semver": "^5.5.0"
+                "pretty-format": "^25.3.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "make-dir": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+                    "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^6.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "jest-transform-stub": {
@@ -6253,120 +7635,239 @@
             "dev": true
         },
         "jest-util": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
-            "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.3.0.tgz",
+            "integrity": "sha512-dc625P/KS/CpWTJJJxKc4bA3A6c+PJGBAqS8JTJqx4HqPoKNqXg/Ec8biL2Z1TabwK7E7Ilf0/ukSEXM1VwzNA==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "callsites": "^3.0.0",
-                "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.15",
+                "@jest/types": "^25.3.0",
+                "chalk": "^3.0.0",
                 "is-ci": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0"
+                "make-dir": "^3.0.0"
             },
             "dependencies": {
-                "callsites": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-                    "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-                    "dev": true
-                },
-                "ci-info": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-                    "dev": true
-                },
-                "graceful-fs": {
-                    "version": "4.1.15",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-                    "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-                    "dev": true
-                },
-                "is-ci": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "ci-info": "^2.0.0"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
+                },
+                "make-dir": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+                    "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^6.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
         "jest-validate": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
-            "integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.3.0.tgz",
+            "integrity": "sha512-3WuXgIZ4HXUvW6gk9twFFkT9j6zUorKnF2oEY8VEsHb7x5LGvVlN3WUsbqazVKuyXwvikO2zFJ/YTySMsMje2w==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "camelcase": "^5.0.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.8.0",
-                "leven": "^2.1.0",
-                "pretty-format": "^24.8.0"
+                "@jest/types": "^25.3.0",
+                "camelcase": "^5.3.1",
+                "chalk": "^3.0.0",
+                "jest-get-type": "^25.2.6",
+                "leven": "^3.1.0",
+                "pretty-format": "^25.3.0"
             },
             "dependencies": {
-                "jest-get-type": {
-                    "version": "24.8.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-                    "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
         "jest-watcher": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
-            "integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.3.0.tgz",
+            "integrity": "sha512-dtFkfidFCS9Ucv8azOg2hkiY3sgJEHeTLtGFHS+jfBEE7eRtrO6+2r1BokyDkaG2FOD7485r/SgpC1MFAENfeA==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "@types/yargs": "^12.0.9",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "jest-util": "^24.8.0",
-                "string-length": "^2.0.0"
+                "@jest/test-result": "^25.3.0",
+                "@jest/types": "^25.3.0",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^3.0.0",
+                "jest-util": "^25.3.0",
+                "string-length": "^3.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "jest-worker": {
-            "version": "24.6.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
-            "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
+            "integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
             "dev": true,
             "requires": {
-                "merge-stream": "^1.0.1",
-                "supports-color": "^6.1.0"
+                "merge-stream": "^2.0.0",
+                "supports-color": "^7.0.0"
             },
             "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
                 "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -6388,44 +7889,53 @@
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "jsdom": {
-            "version": "11.11.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/jsdom/-/jsdom-11.11.0.tgz",
-            "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+            "version": "15.2.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+            "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
             "dev": true,
             "requires": {
-                "abab": "^1.0.4",
-                "acorn": "^5.3.0",
-                "acorn-globals": "^4.1.0",
+                "abab": "^2.0.0",
+                "acorn": "^7.1.0",
+                "acorn-globals": "^4.3.2",
                 "array-equal": "^1.0.0",
-                "cssom": ">= 0.3.2 < 0.4.0",
-                "cssstyle": ">= 0.3.1 < 0.4.0",
-                "data-urls": "^1.0.0",
-                "domexception": "^1.0.0",
-                "escodegen": "^1.9.0",
+                "cssom": "^0.4.1",
+                "cssstyle": "^2.0.0",
+                "data-urls": "^1.1.0",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.11.1",
                 "html-encoding-sniffer": "^1.0.2",
-                "left-pad": "^1.2.0",
-                "nwsapi": "^2.0.0",
-                "parse5": "4.0.0",
+                "nwsapi": "^2.2.0",
+                "parse5": "5.1.0",
                 "pn": "^1.1.0",
-                "request": "^2.83.0",
-                "request-promise-native": "^1.0.5",
-                "sax": "^1.2.4",
+                "request": "^2.88.0",
+                "request-promise-native": "^1.0.7",
+                "saxes": "^3.1.9",
                 "symbol-tree": "^3.2.2",
-                "tough-cookie": "^2.3.3",
+                "tough-cookie": "^3.0.1",
                 "w3c-hr-time": "^1.0.1",
+                "w3c-xmlserializer": "^1.1.2",
                 "webidl-conversions": "^4.0.2",
-                "whatwg-encoding": "^1.0.3",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^6.4.1",
-                "ws": "^4.0.0",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^7.0.0",
+                "ws": "^7.0.0",
                 "xml-name-validator": "^3.0.0"
             },
             "dependencies": {
@@ -6445,9 +7955,9 @@
                     "dev": true
                 },
                 "whatwg-url": {
-                    "version": "6.5.0",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/whatwg-url/-/whatwg-url-6.5.0.tgz",
-                    "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+                    "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
                     "dev": true,
                     "requires": {
                         "lodash.sortby": "^4.7.0",
@@ -6456,6 +7966,12 @@
                     }
                 }
             }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -6470,9 +7986,9 @@
             "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json-stringify-safe": {
@@ -6522,17 +8038,20 @@
             "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true
         },
-        "left-pad": {
-            "version": "1.3.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/left-pad/-/left-pad-1.3.0.tgz",
-            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+        "leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true
         },
-        "leven": {
-            "version": "2.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/leven/-/leven-2.1.0.tgz",
-            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-            "dev": true
+        "levenary": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+            "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+            "dev": true,
+            "requires": {
+                "leven": "^3.1.0"
+            }
         },
         "levn": {
             "version": "0.3.0",
@@ -6552,6 +8071,15 @@
                 "big.js": "^3.1.3",
                 "emojis-list": "^2.0.0",
                 "json5": "^0.5.0"
+            }
+        },
+        "locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^4.1.0"
             }
         },
         "lodash": {
@@ -6581,6 +8109,15 @@
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
+        },
+        "lolex": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+            "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
         },
         "loose-envify": {
             "version": "1.3.1",
@@ -6622,15 +8159,6 @@
                 "tmpl": "1.0.x"
             }
         },
-        "map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "requires": {
-                "p-defer": "^1.0.0"
-            }
-        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/map-cache/-/map-cache-0.2.2.tgz",
@@ -6647,13 +8175,10 @@
             }
         },
         "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^2.0.1"
-            }
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "merge2": {
             "version": "1.2.3",
@@ -6691,19 +8216,25 @@
             }
         },
         "mime-db": {
-            "version": "1.33.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/mime-db/-/mime-db-1.33.0.tgz",
-            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+            "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.18",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/mime-types/-/mime-types-2.1.18.tgz",
-            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+            "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.43.0"
             }
+        },
+        "mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -6804,12 +8335,6 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
-        "neo-async": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-            "dev": true
-        },
         "nested-error-stacks": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
@@ -6854,17 +8379,33 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+            "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "growly": "^1.3.0",
-                "is-wsl": "^1.1.0",
-                "semver": "^5.5.0",
+                "is-wsl": "^2.1.1",
+                "semver": "^6.3.0",
                 "shellwords": "^0.1.1",
-                "which": "^1.3.0"
+                "which": "^1.3.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true,
+                    "optional": true
+                }
             }
+        },
+        "node-releases": {
+            "version": "1.1.53",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+            "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==",
+            "dev": true
         },
         "nopt": {
             "version": "3.0.6",
@@ -6905,22 +8446,16 @@
                 "path-key": "^2.0.0"
             }
         },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
         "nwsapi": {
-            "version": "2.0.4",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/nwsapi/-/nwsapi-2.0.4.tgz",
-            "integrity": "sha512-Zt6HRR6RcJkuj5/N9zeE7FN6YitRW//hK2wTOwX274IBphbY3Zf5+yn5mZ9v/SzAOTMjQNxZf9KkmPLWn0cV4g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
         "object-assign": {
@@ -6965,14 +8500,16 @@
                 "isobject": "^3.0.0"
             }
         },
-        "object.getownpropertydescriptors": {
-            "version": "2.0.3",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.pick": {
@@ -7010,52 +8547,34 @@
                 "wrappy": "1"
             }
         },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+        "onetime": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+            "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "mimic-fn": "^2.1.0"
             }
         },
         "optionator": {
-            "version": "0.8.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/optionator/-/optionator-0.8.2.tgz",
-            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
             "dev": true,
             "requires": {
                 "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
+                "fast-levenshtein": "~2.0.6",
                 "levn": "~0.3.0",
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "1.0.0",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
-                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-                    "dev": true
-                }
+                "word-wrap": "~1.2.3"
             }
-        },
-        "p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-            "dev": true
         },
         "p-each-series": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-            "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-            "dev": true,
-            "requires": {
-                "p-reduce": "^1.0.0"
-            }
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+            "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+            "dev": true
         },
         "p-finally": {
             "version": "1.0.0",
@@ -7063,22 +8582,34 @@
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
             "dev": true
         },
-        "p-is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-            "dev": true
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
         },
-        "p-reduce": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-            "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+        "p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.2.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
         "parse5": {
-            "version": "4.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/parse5/-/parse5-4.0.0.tgz",
-            "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+            "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
             "dev": true
         },
         "pascalcase": {
@@ -7123,6 +8654,12 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
+        "picomatch": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "dev": true
+        },
         "pirates": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -7130,6 +8667,69 @@
             "dev": true,
             "requires": {
                 "node-modules-regexp": "^1.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^4.0.0"
+            }
+        },
+        "pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.1.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                }
             }
         },
         "pn": {
@@ -7173,39 +8773,70 @@
             }
         },
         "pretty-format": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
-            "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.3.0.tgz",
+            "integrity": "sha512-wToHwF8bkQknIcFkBqNfKu4+UZqnrLn/Vr+wwKQwwvPzkBfDDKp/qIabFqdgtoi5PEnM8LFByVsOrHoa3SpTVA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "ansi-regex": "^4.0.0",
-                "ansi-styles": "^3.2.0",
-                "react-is": "^16.8.4"
+                "@jest/types": "^25.3.0",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^4.0.0",
+                "react-is": "^16.12.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "react-is": {
+                    "version": "16.13.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
                     "dev": true
                 }
             }
         },
-        "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
             "dev": true
         },
         "prompts": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-            "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+            "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
             "dev": true,
             "requires": {
-                "kleur": "^3.0.2",
-                "sisteransi": "^1.0.0"
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.4"
             }
         },
         "prop-types": {
@@ -7241,9 +8872,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.28",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/psl/-/psl-1.1.28.tgz",
-            "integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
             "dev": true
         },
         "pump": {
@@ -7300,35 +8931,42 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
             "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
         },
-        "readable-stream": {
-            "version": "2.3.6",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-            "dev": true,
-            "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
         "realpath-native": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+            "dev": true
+        },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+            "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
             "dev": true,
             "requires": {
-                "util.promisify": "^1.0.0"
+                "regenerate": "^1.4.0"
             }
         },
         "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "version": "0.13.5",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+            "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
             "dev": true
+        },
+        "regenerator-transform": {
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
+            "integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.8.4",
+                "private": "^0.1.8"
+            }
         },
         "regex-not": {
             "version": "1.0.2",
@@ -7338,6 +8976,43 @@
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
+            }
+        },
+        "regexpu-core": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+            "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^8.2.0",
+                "regjsgen": "^0.5.1",
+                "regjsparser": "^0.6.4",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.2.0"
+            }
+        },
+        "regjsgen": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+            "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+            "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
             }
         },
         "remove-trailing-separator": {
@@ -7359,68 +9034,83 @@
             "dev": true
         },
         "request": {
-            "version": "2.87.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/request/-/request-2.87.0.tgz",
-            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
+                "aws4": "^1.8.0",
                 "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
                 "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "uuid": "^3.3.2"
             },
             "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                },
                 "tough-cookie": {
-                    "version": "2.3.4",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/tough-cookie/-/tough-cookie-2.3.4.tgz",
-                    "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+                    "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
                     "dev": true,
                     "requires": {
-                        "punycode": "^1.4.1"
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
                     }
                 }
             }
         },
         "request-promise-core": {
-            "version": "1.1.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+            "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "^4.17.15"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "request-promise-native": {
-            "version": "1.0.5",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/request-promise-native/-/request-promise-native-1.0.5.tgz",
-            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+            "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
             "dev": true,
             "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "request-promise-core": "1.1.3",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            },
+            "dependencies": {
+                "tough-cookie": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+                    "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                }
             }
         },
         "require-directory": {
@@ -7430,9 +9120,9 @@
             "dev": true
         },
         "require-main-filename": {
-            "version": "1.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
         "requirejs": {
@@ -7447,18 +9137,18 @@
             "dev": true
         },
         "resolve-cwd": {
-            "version": "2.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "^5.0.0"
             }
         },
         "resolve-from": {
-            "version": "3.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/resolve-from/-/resolve-from-3.0.0.tgz",
-            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true
         },
         "resolve-url": {
@@ -7474,28 +9164,12 @@
             "dev": true
         },
         "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                }
             }
         },
         "rollup": {
@@ -7707,11 +9381,14 @@
                 }
             }
         },
-        "sax": {
-            "version": "1.2.4",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-            "dev": true
+        "saxes": {
+            "version": "3.1.11",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+            "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+            "dev": true,
+            "requires": {
+                "xmlchars": "^2.1.1"
+            }
         },
         "scheduler": {
             "version": "0.13.6",
@@ -7776,7 +9453,8 @@
             "version": "0.1.1",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/shellwords/-/shellwords-0.1.1.tgz",
             "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "sigmund": {
             "version": "1.0.1",
@@ -7791,9 +9469,15 @@
             "dev": true
         },
         "sisteransi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
-            "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true
+        },
+        "slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
         "snapdragon": {
@@ -7925,6 +9609,24 @@
                 "urix": "^0.1.0"
             }
         },
+        "source-map-support": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+            "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -7972,10 +9674,16 @@
                 "extend-shallow": "^3.0.0"
             }
         },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
         "sshpk": {
-            "version": "1.14.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/sshpk/-/sshpk-1.14.2.tgz",
-            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
@@ -7990,9 +9698,9 @@
             }
         },
         "stack-utils": {
-            "version": "1.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/stack-utils/-/stack-utils-1.0.1.tgz",
-            "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
             "dev": true
         },
         "static-extend": {
@@ -8023,47 +9731,56 @@
             "dev": true
         },
         "string-length": {
-            "version": "2.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/string-length/-/string-length-2.0.0.tgz",
-            "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+            "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
             "dev": true,
             "requires": {
                 "astral-regex": "^1.0.0",
-                "strip-ansi": "^4.0.0"
-            }
-        },
-        "string-width": {
-            "version": "2.1.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dev": true,
-            "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            }
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
-        "strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^3.0.0"
+                "strip-ansi": "^5.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "string-width": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+            "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+            "dev": true,
+            "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
                 }
             }
@@ -8078,6 +9795,12 @@
             "version": "1.0.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
         },
         "strip-json-comments": {
@@ -8095,16 +9818,80 @@
                 "has-flag": "^3.0.0"
             }
         },
+        "supports-hyperlinks": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+            "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "symbol-tree": {
-            "version": "3.2.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/symbol-tree/-/symbol-tree-3.2.2.tgz",
-            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "terminal-link": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+            "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "supports-hyperlinks": "^2.0.0"
+            }
+        },
+        "test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "requires": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
         "throat": {
-            "version": "4.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/throat/-/throat-4.1.0.tgz",
-            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+            "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
             "dev": true
         },
         "tmpl": {
@@ -8151,33 +9938,20 @@
             }
         },
         "tough-cookie": {
-            "version": "2.4.3",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
             "dev": true,
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                }
+                "ip-regex": "^2.1.0",
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tr46": {
             "version": "0.0.3",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "trim-right": {
-            "version": "1.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/trim-right/-/trim-right-1.0.1.tgz",
-            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-            "dev": true
         },
         "ts-jest": {
             "version": "24.0.2",
@@ -8243,8 +10017,7 @@
             "version": "0.14.5",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "type-check": {
             "version": "0.3.2",
@@ -8255,38 +10028,60 @@
                 "prelude-ls": "~1.1.2"
             }
         },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
+        },
+        "type-fest": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+            "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+            "dev": true
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "requires": {
+                "is-typedarray": "^1.0.0"
+            }
+        },
         "typescript": {
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
             "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
-        "uglify-js": {
-            "version": "3.5.15",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
-            "integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
             "dev": true,
-            "optional": true,
             "requires": {
-                "commander": "~2.20.0",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-                    "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-                    "dev": true,
-                    "optional": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true,
-                    "optional": true
-                }
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
             }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+            "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+            "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
+            "dev": true
         },
         "union-value": {
             "version": "1.0.0",
@@ -8369,6 +10164,15 @@
                 }
             }
         },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
         "urix": {
             "version": "0.1.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/urix/-/urix-0.1.0.tgz",
@@ -8392,27 +10196,39 @@
                 }
             }
         },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+        "uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "dev": true
         },
-        "util.promisify": {
-            "version": "1.0.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/util.promisify/-/util.promisify-1.0.0.tgz",
-            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+        "v8-to-istanbul": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.3.tgz",
+            "integrity": "sha512-sAjOC+Kki6aJVbUOXJbcR0MnbfjvBzwKZazEJymA2IX49uoOdEdk+4fBq5cXgYgiyKtAyrrJNtBZdOeDIF+Fng==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "object.getownpropertydescriptors": "^2.0.3"
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^1.6.0",
+                "source-map": "^0.7.3"
+            },
+            "dependencies": {
+                "convert-source-map": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+                    "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                }
             }
-        },
-        "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-            "dev": true
         },
         "validate-npm-package-license": {
             "version": "3.0.3",
@@ -8465,12 +10281,31 @@
             "dev": true
         },
         "w3c-hr-time": {
-            "version": "1.0.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-            "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "^0.1.2"
+                "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "w3c-xmlserializer": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+            "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+            "dev": true,
+            "requires": {
+                "domexception": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "webidl-conversions": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+                    "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+                    "dev": true
+                }
             }
         },
         "walker": {
@@ -8488,19 +10323,22 @@
             "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
         },
         "whatwg-encoding": {
-            "version": "1.0.3",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-            "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
             "dev": true,
             "requires": {
-                "iconv-lite": "0.4.19"
+                "iconv-lite": "0.4.24"
             },
             "dependencies": {
                 "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-                    "dev": true
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
                 }
             }
         },
@@ -8510,9 +10348,9 @@
             "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         },
         "whatwg-mimetype": {
-            "version": "2.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-            "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
             "dev": true
         },
         "whatwg-url": {
@@ -8539,50 +10377,47 @@
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
         },
-        "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
         },
         "wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
             },
             "dependencies": {
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "color-name": "~1.1.4"
                     }
                 },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 }
             }
         },
@@ -8642,14 +10477,10 @@
             }
         },
         "ws": {
-            "version": "4.1.0",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/ws/-/ws-4.1.0.tgz",
-            "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-            "dev": true,
-            "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0"
-            }
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+            "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+            "dev": true
         },
         "xml-name-validator": {
             "version": "3.0.0",
@@ -8657,11 +10488,48 @@
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
             "dev": true
         },
-        "y18n": {
-            "version": "3.2.1",
-            "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+        "xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yargs": {
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+            "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+            "dev": true,
+            "requires": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.1"
+            },
+            "dependencies": {
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
         },
         "yargs-parser": {
             "version": "10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8104,6 +8104,12 @@
             "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
             "dev": true
         },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+            "dev": true
+        },
         "lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -8145,9 +8151,9 @@
             }
         },
         "make-error": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
         "makeerror": {
@@ -9954,36 +9960,93 @@
             "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
         },
         "ts-jest": {
-            "version": "24.0.2",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.0.2.tgz",
-            "integrity": "sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==",
+            "version": "25.4.0",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.4.0.tgz",
+            "integrity": "sha512-+0ZrksdaquxGUBwSdTIcdX7VXdwLIlSRsyjivVA9gcO+Cvr6ByqDhu/mi5+HCcb6cMkiQp5xZ8qRO7/eCqLeyw==",
             "dev": true,
             "requires": {
                 "bs-logger": "0.x",
                 "buffer-from": "1.x",
                 "fast-json-stable-stringify": "2.x",
                 "json5": "2.x",
+                "lodash.memoize": "4.x",
                 "make-error": "1.x",
-                "mkdirp": "0.x",
+                "micromatch": "4.x",
+                "mkdirp": "1.x",
                 "resolve": "1.x",
-                "semver": "^5.5",
-                "yargs-parser": "10.x"
+                "semver": "6.x",
+                "yargs-parser": "18.x"
             },
             "dependencies": {
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.0"
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
                     }
                 },
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
                 }
             }
         },
@@ -10532,20 +10595,13 @@
             }
         },
         "yargs-parser": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-            "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://wizdom.pkgs.visualstudio.com/_packaging/WizdomModern/npm/registry/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-                    "dev": true
-                }
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
             }
         },
         "z-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.4.13",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,17 @@
         "tslib": "^1.11.1"
     },
     "devDependencies": {
+        "@babel/core": "^7.9.0",
+        "@babel/preset-env": "^7.9.5",
         "@types/chai": "^4.1.7",
         "@types/jest": "^24.0.13",
         "@types/mocha": "^5.2.6",
-        "jest": "^24.8.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "babel-jest": "^25.3.0",
+        "jest": "^25.3.0",
         "jest-serializer-vue": "^2.0.2",
         "jest-transform-stub": "^2.0.0",
+        "regenerator-runtime": "^0.13.5",
         "rollup": "^0.50.0",
         "rollup-plugin-cpy": "^1.1.0",
         "rollup-plugin-generate-package-json": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "author": "Wizdom A/S",
     "license": "MIT",
     "dependencies": {
-        "@microsoft/sp-application-base": "^1.8.2",
-        "@microsoft/sp-core-library": "^1.8.2",
-        "@microsoft/sp-extension-base": "^1.8.2",
-        "@microsoft/sp-http": "^1.8.2",
-        "@microsoft/sp-webpart-base": "^1.8.2",
-        "es6-promise": "^4.2.6"
+        "@microsoft/sp-application-base": "^1.10.0",
+        "@microsoft/sp-core-library": "^1.10.0",
+        "@microsoft/sp-extension-base": "^1.10.0",
+        "@microsoft/sp-http": "^1.10.0",
+        "@microsoft/sp-webpart-base": "^1.10.0",
+        "es6-promise": "^4.2.6",
+        "tslib": "^1.11.1"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",
@@ -35,7 +36,7 @@
         "rollup-plugin-sourcemaps": "^0.4.2",
         "rollup-plugin-typescript2": "^0.8.1",
         "ts-jest": "^24.0.2",
-        "typescript": "^3.4.5",
+        "typescript": "^3.8.3",
         "vue-jest": "^3.0.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "rollup-plugin-generate-package-json": "^2.0.1",
         "rollup-plugin-sourcemaps": "^0.4.2",
         "rollup-plugin-typescript2": "^0.8.1",
-        "ts-jest": "^24.0.2",
+        "ts-jest": "^25.4.0",
         "typescript": "^3.8.3",
         "vue-jest": "^3.0.4"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wizdom-intranet/services",
-    "version": "1.4.13",
+    "version": "2.0.0",
     "description": "A list of core service to ease Wizdom development",
     "main": "dist/index.js",
     "types": "dist/main.d.ts",

--- a/src/services/caching/cache.pageview.ts
+++ b/src/services/caching/cache.pageview.ts
@@ -32,7 +32,7 @@ export class WizdomPageViewCache implements IWizdomPageViewCache {
      * @param func  Any function
      * @param expiresInMilliseconds  The func will not be invoked again within the expire period.
      */
-    public async ExecuteCached<T>(key: string, func: Function, expiresInMilliseconds: number) : Promise<T> {            
+    public ExecuteCached<T>(key: string, func: Function, expiresInMilliseconds: number) : T {          
         var cacheObj = this.GetCacheObject(key);
         if (!this.forceNoCache && cacheObj && cacheObj.created) {
             var now = new Date(Date.now());
@@ -43,7 +43,7 @@ export class WizdomPageViewCache implements IWizdomPageViewCache {
                 return cacheObj.data as T;            
             }            
         }
-        var result = await func();
+        var result = func();
         this.SetCacheObject(key, result);
         return result as T;        
     }

--- a/src/services/caching/cache.pageview.ts
+++ b/src/services/caching/cache.pageview.ts
@@ -32,7 +32,7 @@ export class WizdomPageViewCache implements IWizdomPageViewCache {
      * @param func  Any function
      * @param expiresInMilliseconds  The func will not be invoked again within the expire period.
      */
-    public ExecuteCached<T>(key: string, func: Function, expiresInMilliseconds: number) : T {            
+    public async ExecuteCached<T>(key: string, func: Function, expiresInMilliseconds: number) : Promise<T> {            
         var cacheObj = this.GetCacheObject(key);
         if (!this.forceNoCache && cacheObj && cacheObj.created) {
             var now = new Date(Date.now());
@@ -43,7 +43,7 @@ export class WizdomPageViewCache implements IWizdomPageViewCache {
                 return cacheObj.data as T;            
             }            
         }
-        var result = func();
+        var result = await func();
         this.SetCacheObject(key, result);
         return result as T;        
     }

--- a/src/services/caching/cache.timestamps.ts
+++ b/src/services/caching/cache.timestamps.ts
@@ -79,7 +79,8 @@ export class WizdomTimestamps implements IWizdomTimestamps, IWizdomTimestampsRes
     return this.GetTimestampsPromise()
       .then(json => {
         let result = 0;
-        let keys = [key, "timestampconfiguration", ...this.getGlobalMappings()[key]];
+        let globalMappings = this.getGlobalMappings()[key] ?? [];
+        let keys = [key, "timestampconfiguration", ...globalMappings];
         keys.forEach(k => {
           if (k && json[k]) result = Math.max(result, json[k]);
         });

--- a/src/services/configuration/configuration.ts
+++ b/src/services/configuration/configuration.ts
@@ -15,7 +15,8 @@ export async function GetWizdomConfiguration(httpClient : any, context : IWizdom
                 try {
                     return JSON.parse(content);
                 }
-                catch {
+                catch(ex) {
+                    console.error("Failed parsing Wizdom configuration", ex)
                     return null;
                 }
             });

--- a/src/services/configuration/configuration.ts
+++ b/src/services/configuration/configuration.ts
@@ -12,7 +12,12 @@ export async function GetWizdomConfiguration(httpClient : any, context : IWizdom
         return httpClient.get(configurationUrl).then(result => {            
             return result.text().then(content => {
                 content = content.substring(content.indexOf("{"), content.lastIndexOf("}") + 1); // remove all the angular stuff and only save the json
-                return JSON.parse(content);
+                try {
+                    return JSON.parse(content);
+                }
+                catch {
+                    return null;
+                }
             });
         });
     }, expireIn, refreshIn, refreshDelayIn).then((configuration:any) => {          

--- a/src/services/context/__tests__/context.spec.ts
+++ b/src/services/context/__tests__/context.spec.ts
@@ -58,7 +58,7 @@ describe("WizdomContext", () => {
                 })
             }
         }
-        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null);
+        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null, null);
         var context = await sut.GetWizdomContextAsync("http://sharepoint.site/absolute/url/");
         expect(context.blobUrl).toEqual("http://blob/site/");
         expect(context.appUrl).toEqual("http://app/site/");
@@ -75,7 +75,7 @@ describe("WizdomContext", () => {
             },
             siteProperties:{}
         }
-        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null);
+        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null, null);
         var context = await sut.GetWizdomContextAsync("http://sharepoint.site/absolute/url/");
         expect(context.blobUrl).toEqual("http://blob/tenant/");
         expect(context.appUrl).toEqual("http://app/tenant/");
@@ -92,7 +92,7 @@ describe("WizdomContext", () => {
                 })
             }
         }
-        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null);
+        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null, null);
         var context = await sut.GetWizdomContextAsync("http://sharepoint.site/absolute/url/");
         expect(context.blobUrl).toEqual("http://blob/site/");
         expect(context.appUrl).toEqual("http://app/site/");
@@ -115,7 +115,7 @@ describe("WizdomContext", () => {
                 })
             }
         }
-        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null);
+        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), null, null);
         var context = await sut.GetWizdomContextAsync("http://sharepoint.site/absolute/url/");
         expect(context.blobUrl).toEqual("http://blob/site/");
         expect(context.appUrl).toEqual("http://app/site/");
@@ -147,7 +147,7 @@ describe("WizdomContext", () => {
             }
         } as IWizdomDeveloperMode;
 
-        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), developerMode);
+        var sut = new WizdomContextFactory(getSpHttpClient(mockData), getCacheMock(), developerMode, null);
         var context = await sut.GetWizdomContextAsync("http://sharepoint.site/absolute/url/");
         expect(context.blobUrl).toEqual("http://blob/developermode/");
         expect(context.appUrl).toEqual("http://app/developermode/");

--- a/src/services/context/context.factory.ts
+++ b/src/services/context/context.factory.ts
@@ -83,15 +83,13 @@ export class WizdomContextFactory {
                 if(this.wizdomdevelopermode?.wizdomContext?.appUrl) {
                     wizdomInfo.appUrl = this.storageEntityContext.appUrl || "https://wtsaas.azurewebsites.net/";
                 }
-                
-                // Append a / to the end of the urls if it's not there
-                this.storageEntityContext.appUrl += this.storageEntityContext.appUrl.indexOf("/", -1) !== -1 ? "" : "/";
-                this.storageEntityContext.blobUrl += this.storageEntityContext.blobUrl.indexOf("/", -1) !== -1 ? "" : "/";
-
+            
                 this.storageEntityContext = {...this.storageEntityContext, ...wizdomInfo};
             }
 
-            
+            // Append a / to the end of the urls if it's not there
+            this.storageEntityContext.appUrl += this.storageEntityContext.appUrl.indexOf("/", -1) !== -1 ? "" : "/";
+            this.storageEntityContext.blobUrl += this.storageEntityContext.blobUrl.indexOf("/", -1) !== -1 ? "" : "/";
 
             return this.storageEntityContext;
 

--- a/src/services/context/context.factory.ts
+++ b/src/services/context/context.factory.ts
@@ -31,12 +31,6 @@ export class WizdomContextFactory {
                     if(json.Value)
                     {
                         var context: IWizdomContext = JSON.parse(json.Value);
-                        // ensure tailing / for app- and bloburl
-                        if (context.blobUrl.substr(-1) != "/")
-                            context.blobUrl = context.blobUrl + "/";
-                        if (context.appUrl.substr(-1) != "/")
-                            context.appUrl = context.appUrl + "/";
-    
                         this.storageEntityContext = context;
                     }
                 });
@@ -47,12 +41,6 @@ export class WizdomContextFactory {
                 return result.json().then((json) => {
                     if (json.wizdom_x002e_properties) {
                         var context: IWizdomContext = JSON.parse(json.wizdom_x002e_properties);
-                        // ensure tailing / for app- and bloburl
-                        if (context.blobUrl.substr(-1) != "/")
-                            context.blobUrl = context.blobUrl + "/";
-                        if (context.appUrl.substr(-1) != "/")
-                            context.appUrl = context.appUrl + "/";
-
                         this.allPropertiesContext = context;
                     }
                 });
@@ -87,9 +75,12 @@ export class WizdomContextFactory {
                 this.storageEntityContext = {...this.storageEntityContext, ...wizdomInfo};
             }
 
-            // Append a / to the end of the urls if it's not there
-            this.storageEntityContext.appUrl += this.storageEntityContext.appUrl.indexOf("/", -1) !== -1 ? "" : "/";
-            this.storageEntityContext.blobUrl += this.storageEntityContext.blobUrl.indexOf("/", -1) !== -1 ? "" : "/";
+            // ensure tailing / for app- and bloburl
+            if (this.storageEntityContext.blobUrl.substr(-1) != "/")
+                this.storageEntityContext.blobUrl = this.storageEntityContext.blobUrl + "/";
+            if (this.storageEntityContext.appUrl.substr(-1) != "/")
+                this.storageEntityContext.appUrl = this.storageEntityContext.appUrl + "/";
+
 
             return this.storageEntityContext;
 

--- a/src/services/context/context.factory.ts
+++ b/src/services/context/context.factory.ts
@@ -84,8 +84,14 @@ export class WizdomContextFactory {
                     wizdomInfo.appUrl = this.storageEntityContext.appUrl || "https://wtsaas.azurewebsites.net/";
                 }
                 
+                // Append a / to the end of the urls if it's not there
+                this.storageEntityContext.appUrl += this.storageEntityContext.appUrl.indexOf("/", -1) !== -1 ? "" : "/";
+                this.storageEntityContext.blobUrl += this.storageEntityContext.blobUrl.indexOf("/", -1) !== -1 ? "" : "/";
+
                 this.storageEntityContext = {...this.storageEntityContext, ...wizdomInfo};
             }
+
+            
 
             return this.storageEntityContext;
 

--- a/src/services/context/context.interfaces.ts
+++ b/src/services/context/context.interfaces.ts
@@ -3,4 +3,10 @@ export interface IWizdomContext {
     blobUrl: string;
     clientId: string;
     wizdomdevelopermode: any;
+    isWizdomSaaS: boolean;
+    serverContext: {
+        allWizdomRoles: string[];
+        rolesForCurrentUser: string[];
+        currentUserLanguage: string;
+    }
 } 

--- a/src/services/translations/translation.service.factory.ts
+++ b/src/services/translations/translation.service.factory.ts
@@ -28,8 +28,13 @@ export class WizdomTranslationServiceFactory {
             var jsonStartIndex = content.indexOf("{");
             var jsonEndIndex = content.indexOf("}}") + 2;
             content = content.substr(jsonStartIndex, jsonEndIndex - jsonStartIndex); // remove all the angular stuff and only save the json
-            let translations: any = JSON.parse(content)[language.toLowerCase()];            
-            return translations;
+            try{
+                let translations: any = JSON.parse(content)[language.toLowerCase()];            
+                return translations;
+            }
+            catch {
+                return null;
+            }
         }, expireIn, refreshIn, refreshDelayIn)
         .then((translations) => {
             // Store a global variable

--- a/src/services/translations/translation.service.factory.ts
+++ b/src/services/translations/translation.service.factory.ts
@@ -28,7 +28,7 @@ export class WizdomTranslationServiceFactory {
             var jsonStartIndex = content.indexOf("{");
             var jsonEndIndex = content.indexOf("}}") + 2;
             content = content.substr(jsonStartIndex, jsonEndIndex - jsonStartIndex); // remove all the angular stuff and only save the json
-            var translations = JSON.parse(content)[language.toLowerCase()];            
+            let translations: any = JSON.parse(content)[language.toLowerCase()];            
             return translations;
         }, expireIn, refreshIn, refreshDelayIn)
         .then((translations) => {

--- a/src/services/translations/translation.service.factory.ts
+++ b/src/services/translations/translation.service.factory.ts
@@ -32,7 +32,8 @@ export class WizdomTranslationServiceFactory {
                 let translations: any = JSON.parse(content)[language.toLowerCase()];            
                 return translations;
             }
-            catch {
+            catch(ex) {
+                console.error("Failed parsing Wizdom translations", ex)
                 return null;
             }
         }, expireIn, refreshIn, refreshDelayIn)

--- a/src/services/translations/translation.service.ts
+++ b/src/services/translations/translation.service.ts
@@ -3,7 +3,7 @@ import { IWizdomDeveloperMode } from "../../shared/developermode.interface";
 
 export class WizdomTranslationService implements IWizdomTranslationService {
     
-    constructor(private translations: object, private wizdomdevelopermode: IWizdomDeveloperMode) {    
+    constructor(private translations: any, private wizdomdevelopermode: IWizdomDeveloperMode) {    
     }
 
     translate(key: string): string {        

--- a/src/services/webapi/__tests__/webapi.service.factory.spec.ts
+++ b/src/services/webapi/__tests__/webapi.service.factory.spec.ts
@@ -15,7 +15,7 @@ describe("WizdomWebApiServiceFactory", () => {
         } as IWizdomCorsProxyService
 
         var fakeCorsProxyFactory = { GetOrCreate(){ return corsProxy; } } as IWizdomCorsProxyServiceFactory;
-        webapiServiceFactory = new WizdomWebApiServiceFactory(fakeCorsProxyFactory, null, {pageContext: {site: {absoluteUrl:"http://sharepointHostUrl.com"}}}, null);
+        webapiServiceFactory = new WizdomWebApiServiceFactory(fakeCorsProxyFactory, null, "http://sharepointHostUrl.com", null);
     });
 
     it("should expose WizdomWebApiService on window object", async () => {

--- a/src/services/webapi/__tests__/webapi.service.factory.spec.ts
+++ b/src/services/webapi/__tests__/webapi.service.factory.spec.ts
@@ -15,7 +15,7 @@ describe("WizdomWebApiServiceFactory", () => {
         } as IWizdomCorsProxyService
 
         var fakeCorsProxyFactory = { GetOrCreate(){ return corsProxy; } } as IWizdomCorsProxyServiceFactory;
-        webapiServiceFactory = new WizdomWebApiServiceFactory(fakeCorsProxyFactory, "http://sharepointHostUrl.com");
+        webapiServiceFactory = new WizdomWebApiServiceFactory(fakeCorsProxyFactory, null, {pageContext: {site: {absoluteUrl:"http://sharepointHostUrl.com"}}}, null);
     });
 
     it("should expose WizdomWebApiService on window object", () => {

--- a/src/services/webapi/__tests__/webapi.service.factory.spec.ts
+++ b/src/services/webapi/__tests__/webapi.service.factory.spec.ts
@@ -18,8 +18,8 @@ describe("WizdomWebApiServiceFactory", () => {
         webapiServiceFactory = new WizdomWebApiServiceFactory(fakeCorsProxyFactory, null, {pageContext: {site: {absoluteUrl:"http://sharepointHostUrl.com"}}}, null);
     });
 
-    it("should expose WizdomWebApiService on window object", () => {
-        var webapiService = webapiServiceFactory.Create();
+    it("should expose WizdomWebApiService on window object", async () => {
+        var webapiService = await webapiServiceFactory.Create();
 
         expect(webapiService).not.toBeNull();
         expect(webapiService).toBe(window["WizdomWebApiService"]);

--- a/src/services/webapi/aad-webapi.service.ts
+++ b/src/services/webapi/aad-webapi.service.ts
@@ -30,7 +30,14 @@ export class WizdomAADWebApiService implements IWizdomWebApiService {
                         this.state.requestRateLimitCounter--;
                     }, requestRateLimitTimeout);
                 }
-                return await (await this.httpClient.fetch(parsedUrl.toString(), AadHttpClient.configurations.v1, {method: method, body: JSON.stringify(data)})).json()
+                return await (await this.httpClient.fetch(parsedUrl.toString(), AadHttpClient.configurations.v1, {
+                    method: method, 
+                    headers: {
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(data)
+                })).text().then(text => text ? JSON.parse(text) : null);
             }
             else
             {

--- a/src/services/webapi/aad-webapi.service.ts
+++ b/src/services/webapi/aad-webapi.service.ts
@@ -30,7 +30,7 @@ export class WizdomAADWebApiService implements IWizdomWebApiService {
                         this.state.requestRateLimitCounter--;
                     }, requestRateLimitTimeout);
                 }
-                return await (await this.httpClient.fetch(parsedUrl.toString(), AadHttpClient.configurations.v1, {method: method, body: data})).json()
+                return await (await this.httpClient.fetch(parsedUrl.toString(), AadHttpClient.configurations.v1, {method: method, body: JSON.stringify(data)})).json()
             }
             else
             {

--- a/src/services/webapi/aad-webapi.service.ts
+++ b/src/services/webapi/aad-webapi.service.ts
@@ -30,14 +30,24 @@ export class WizdomAADWebApiService implements IWizdomWebApiService {
                         this.state.requestRateLimitCounter--;
                     }, requestRateLimitTimeout);
                 }
-                return await (await this.httpClient.fetch(parsedUrl.toString(), AadHttpClient.configurations.v1, {
+
+                let req = await this.httpClient.fetch(parsedUrl.toString(), AadHttpClient.configurations.v1, {
                     method: method, 
                     headers: {
                         'Accept': 'application/json',
                         'Content-Type': 'application/json'
                     },
                     body: JSON.stringify(data)
-                })).text().then(text => text ? JSON.parse(text) : null);
+                });
+
+                let message = await req.text().then(text => text ? JSON.parse(text) : null);
+
+                if(req.ok){
+                    return message;
+                }
+                else {
+                    throw ({errorType: WebApiErrorType.RequestFailed, message: message})
+                }
             }
             else
             {

--- a/src/services/webapi/aad-webapi.service.ts
+++ b/src/services/webapi/aad-webapi.service.ts
@@ -15,8 +15,6 @@ export class WizdomAADWebApiService implements IWizdomWebApiService {
             console.info(`[WizdomWebApi] Sending ${method} request to: ${url}`);
             
             const isExternalRequest = url.indexOf('://') < 10 && url.indexOf('://') >= 0;
-            if(!isExternalRequest && url[0] != "/")
-                url = "/" + url;
 
             let parsedUrl = new URL(isExternalRequest ? url : this.appUrl + url);
 

--- a/src/services/webapi/aad-webapi.service.ts
+++ b/src/services/webapi/aad-webapi.service.ts
@@ -1,0 +1,58 @@
+import { IWizdomWebApiService, IWizdomWebApiServiceState, WebApiErrorType } from "./webapi.interfaces";
+import { IWizdomCorsProxyServiceFactory, IWizdomCorsProxyService } from "../corsproxy/corsproxy.interfaces";
+import { AadHttpClient, IHttpClientOptions } from "@microsoft/sp-http";
+
+
+// max 60 requests/min
+const requestRateLimitCount = 300;
+const requestRateLimitTimeout = 5*60*1000;
+
+export class WizdomAADWebApiService implements IWizdomWebApiService {
+
+    constructor(private spHostUrl: string, private appUrl: string, private state: IWizdomWebApiServiceState, private httpClient: AadHttpClient) {}
+
+    public async makeRequest(url: string, method: string, data?: any): Promise<any> {
+            console.info(`[WizdomWebApi] Sending ${method} request to: ${url}`);
+            
+            const isExternalRequest = url.indexOf('://') < 10 && url.indexOf('://') >= 0;
+            if(!isExternalRequest && url[0] != "/")
+                url = "/" + url;
+
+            let parsedUrl = new URL(isExternalRequest ? url : this.appUrl + url);
+
+            parsedUrl.searchParams.append("SPHostUrl", this.spHostUrl);
+
+            // rateLimit is only for get requests
+            if(this.state.requestRateLimitCounter<requestRateLimitCount || method != "GET")
+            {
+                if(method == "GET")
+                {
+                    this.state.requestRateLimitCounter++;
+                    setTimeout(() => {
+                        this.state.requestRateLimitCounter--;
+                    }, requestRateLimitTimeout);
+                }
+                return await (await this.httpClient.fetch(parsedUrl.toString(), AadHttpClient.configurations.v1, {method: method, body: data})).json()
+            }
+            else
+            {
+                console.error("[WizdomWebApi] Request ratelimit exceeded. More than " + requestRateLimitCount + " was made over a period of " + (requestRateLimitTimeout/1000) + " seconds");
+                throw {errorType: WebApiErrorType.RateLimitExeeded, message: "Request ratelimit exceeded"};
+            }
+
+        }
+
+
+    public async Get(url: string): Promise<any> {
+        return await this.makeRequest(url, "GET");
+    }
+    public async Delete(url: string): Promise<any> {
+        return await this.makeRequest(url, "DELETE");
+    }
+    public async Post(url: string, data: any): Promise<any> {
+        return await this.makeRequest(url, "POST", data);
+    }
+    public async Put(url: string, data: any): Promise<any> {
+        return await this.makeRequest(url, "PUT", data);
+    }
+}

--- a/src/services/webapi/webapi.service.factory.ts
+++ b/src/services/webapi/webapi.service.factory.ts
@@ -6,9 +6,7 @@ import { WizdomAADWebApiService } from "./aad-webapi.service";
 import { AadHttpClient } from "@microsoft/sp-http";
 
 export class WizdomWebApiServiceFactory {
-    private spHostUrl: string;
-    constructor(private corsProxyFactory: IWizdomCorsProxyServiceFactory, private wizdomContext: IWizdomContext, private spContext: any, private aadHttpClientPromise: Promise<AadHttpClient>) {                
-        this.spHostUrl = this.spContext.pageContext.site.absoluteUrl;
+    constructor(private corsProxyFactory: IWizdomCorsProxyServiceFactory, private wizdomContext: IWizdomContext, private spHostUrl: string, private aadHttpClientFactory: (clientId)=>Promise<AadHttpClient>) {                
     }
 
     async Create() : Promise<IWizdomWebApiService> {
@@ -16,7 +14,7 @@ export class WizdomWebApiServiceFactory {
             return window["WizdomWebApiService"];
         }
         if(this.wizdomContext && this.wizdomContext.isWizdomSaaS) {
-            return window["WizdomWebApiService"] = new WizdomAADWebApiService(this.spHostUrl, this.wizdomContext.appUrl, this.getWebApiSharedState(), await this.aadHttpClientPromise);
+            return window["WizdomWebApiService"] = new WizdomAADWebApiService(this.spHostUrl, this.wizdomContext.appUrl, this.getWebApiSharedState(), await this.aadHttpClientFactory(this.wizdomContext.clientId));
         }
         else {
             return window["WizdomWebApiService"] = new WizdomWebApiService(this.spHostUrl, this.getWebApiSharedState(), this.corsProxyFactory);

--- a/src/services/webapi/webapi.service.factory.ts
+++ b/src/services/webapi/webapi.service.factory.ts
@@ -15,8 +15,7 @@ export class WizdomWebApiServiceFactory {
         if(window["WizdomWebApiService"]) {
             return window["WizdomWebApiService"];
         }
-
-        if(this.wizdomContext.isWizdomSaaS) {
+        if(this.wizdomContext && this.wizdomContext.isWizdomSaaS) {
             return window["WizdomWebApiService"] = new WizdomAADWebApiService(this.spHostUrl, this.wizdomContext.appUrl, this.getWebApiSharedState(), await this.aadHttpClientPromise);
         }
         else {

--- a/src/services/webapi/webapi.service.factory.ts
+++ b/src/services/webapi/webapi.service.factory.ts
@@ -2,13 +2,26 @@ import { IWizdomContext } from "../context/context.interfaces";
 import { IWizdomWebApiService, IWizdomWebApiServiceState } from "./webapi.interfaces";
 import { WizdomWebApiService } from "./webapi.service";
 import { IWizdomCorsProxyServiceFactory } from "../corsproxy/corsproxy.interfaces";
+import { WizdomAADWebApiService } from "./aad-webapi.service";
+import { AadHttpClient } from "@microsoft/sp-http";
 
 export class WizdomWebApiServiceFactory {
-    constructor(private corsProxyFactory: IWizdomCorsProxyServiceFactory, private spHostUrl: string) {                
+    private spHostUrl: string;
+    constructor(private corsProxyFactory: IWizdomCorsProxyServiceFactory, private wizdomContext: IWizdomContext, private spContext: any, private aadHttpClientPromise: Promise<AadHttpClient>) {                
+        this.spHostUrl = this.spContext.pageContext.site.absoluteUrl;
     }
 
-    Create() : IWizdomWebApiService {                        
-        return window["WizdomWebApiService"] = window["WizdomWebApiService"] || new WizdomWebApiService(this.spHostUrl, this.getWebApiSharedState(), this.corsProxyFactory);
+    async Create() : Promise<IWizdomWebApiService> {
+        if(window["WizdomWebApiService"]) {
+            return window["WizdomWebApiService"];
+        }
+
+        if(this.wizdomContext.isWizdomSaaS) {
+            return window["WizdomWebApiService"] = new WizdomAADWebApiService(this.spHostUrl, this.wizdomContext.appUrl, this.getWebApiSharedState(), await this.aadHttpClientPromise);
+        }
+        else {
+            return window["WizdomWebApiService"] = new WizdomWebApiService(this.spHostUrl, this.getWebApiSharedState(), this.corsProxyFactory);
+        }
     }
 
     private getWebApiSharedState() {

--- a/src/services/wizdom.spfx.service.ts
+++ b/src/services/wizdom.spfx.service.ts
@@ -44,13 +44,13 @@ export class WizdomSpfxServices {
                     console.error("Invalid developermode", ex);                    
                 }
             }
-
-            let aadHttpClientPromise: Promise<AadHttpClient> = this.spContext.aadHttpClientFactory.getClient("402cbaeb-c52a-43b6-b886-4ad1c44cab6a");
+            // 402cbaeb-c52a-43b6-b886-4ad1c44cab6a
+            let aadHttpClientFactory = (clientId)=>this.spContext.aadHttpClientFactory.getClient(clientId);
 
             // Initialize all services
             this.Cache = new WizdomCache(wizdomdevelopermode, locationWrapper, new SpfxSpHttpClient(this.spContext.spHttpClient), this.spContext.pageContext.site.absoluteUrl);
 
-            var contextFactory = new WizdomContextFactory(new SpfxSpHttpClient(this.spContext.spHttpClient), this.Cache, wizdomdevelopermode, aadHttpClientPromise);
+            var contextFactory = new WizdomContextFactory(new SpfxSpHttpClient(this.spContext.spHttpClient), this.Cache, wizdomdevelopermode, aadHttpClientFactory);
             this.WizdomContext = await contextFactory.GetWizdomContextAsync(this.spContext.pageContext.site.absoluteUrl);    
 
             var language = this.spContext.pageContext.cultureInfo.currentUICultureName;
@@ -102,7 +102,7 @@ export class WizdomSpfxServices {
                 this.WizdomCorsProxyService = new WizdomCorsProxyService(() => {}, window["WizdomCorsProxyState"]);
             }
 
-            var wizdomWebApiServiceFactory = new WizdomWebApiServiceFactory(wizdomCorsProxyServiceFactory, this.WizdomContext, this.spContext, aadHttpClientPromise);
+            var wizdomWebApiServiceFactory = new WizdomWebApiServiceFactory(wizdomCorsProxyServiceFactory, this.WizdomContext, this.spContext.pageContext.site.absoluteUrl, aadHttpClientFactory);
             this.WizdomWebApiService = await wizdomWebApiServiceFactory.Create();
 
             await Promise.all([translationServicePromise, configurationPromise]);

--- a/src/services/wizdom.spfx.service.ts
+++ b/src/services/wizdom.spfx.service.ts
@@ -87,10 +87,10 @@ export class WizdomSpfxServices {
                 window["WizdomCorsProxyState"] = window["WizdomCorsProxyState"] || {            
                     session: "", 
                     msLeftOnToken: 0, 
-                    allWizdomRoles: this.WizdomContext.serverContext.allWizdomRoles, 
-                    rolesForCurrentUser: this.WizdomContext.serverContext.rolesForCurrentUser, 
+                    allWizdomRoles: this.WizdomContext?.serverContext?.allWizdomRoles, 
+                    rolesForCurrentUser: this.WizdomContext?.serverContext?.rolesForCurrentUser, 
                     upgradeInProgress: false,
-                    currentUserLanguage: this.WizdomContext.serverContext.currentUserLanguage,
+                    currentUserLanguage: this.WizdomContext?.serverContext?.currentUserLanguage,
                     corsProxyFailed: false
                 } as IWizdomCorsProxySharedState;
 

--- a/src/services/wizdom.spfx.service.ts
+++ b/src/services/wizdom.spfx.service.ts
@@ -10,9 +10,11 @@ import { IWizdomWebApiService } from "./webapi/webapi.interfaces";
 import { WizdomWebApiServiceFactory } from "./webapi/webapi.service.factory";
 import { IWizdomCorsProxyService } from "./corsproxy/corsproxy.interfaces";
 import { WizdomCorsProxyServiceFactory } from "./corsproxy/corsproxy.service.factory";
+import { IWizdomCorsProxySharedState } from "./corsproxy/corsproxy.interfaces";
 import { IWizdomDeveloperMode } from "../shared/developermode.interface";
 import { LocationWrapper } from "../shared/location.wrapper";
 import { WizdomLanguageUpdate } from "./wizdom.language.update";
+import { AadHttpClient } from "@microsoft/sp-http";
 
 export class WizdomSpfxServices {
     public Cache: IWizdomCache;
@@ -41,10 +43,13 @@ export class WizdomSpfxServices {
                     console.error("Invalid developermode", ex);                    
                 }
             }
+
+            let aadHttpClientPromise: Promise<AadHttpClient> = this.spContext.aadHttpClientFactory.getClient("402cbaeb-c52a-43b6-b886-4ad1c44cab6a");
+
             // Initialize all services
             this.Cache = new WizdomCache(wizdomdevelopermode, locationWrapper, new SpfxSpHttpClient(this.spContext.spHttpClient), this.spContext.pageContext.site.absoluteUrl);
 
-            var contextFactory = new WizdomContextFactory(new SpfxSpHttpClient(this.spContext.spHttpClient), this.Cache, wizdomdevelopermode);
+            var contextFactory = new WizdomContextFactory(new SpfxSpHttpClient(this.spContext.spHttpClient), this.Cache, wizdomdevelopermode, aadHttpClientPromise);
             this.WizdomContext = await contextFactory.GetWizdomContextAsync(this.spContext.pageContext.site.absoluteUrl);    
 
             var language = this.spContext.pageContext.cultureInfo.currentUICultureName;
@@ -61,21 +66,43 @@ export class WizdomSpfxServices {
                 this.WizdomConfiguration = configuration;
             });
 
-            var wizdomCorsProxyServiceFactory = new WizdomCorsProxyServiceFactory(this.WizdomContext, this.spContext.pageContext.site.absoluteUrl, this.spContext.pageContext.user.loginName);        
-            this.WizdomCorsProxyService = wizdomCorsProxyServiceFactory.GetOrCreate();                        
-            var wizdomWebApiServiceFactory = new WizdomWebApiServiceFactory(wizdomCorsProxyServiceFactory, this.spContext.pageContext.site.absoluteUrl);
-            this.WizdomWebApiService = wizdomWebApiServiceFactory.Create();
-                        
-            this.WizdomCorsProxyService.AddHandler("WizdomCorsProxySuccess", () => {
+            let updateWizdomLanguage = () => {
+                var wizdomLanguageUpdate = new WizdomLanguageUpdate(new SpfxSpHttpClient(this.spContext.spHttpClient), this.WizdomWebApiService, this.Cache);
+                wizdomLanguageUpdate.UpdateIfNeededAsync(this.spContext.pageContext.web.absoluteUrl, window["WizdomCorsProxyState"].currentUserLanguage);
+            }
+
+            let wizdomCorsProxyServiceFactory: WizdomCorsProxyServiceFactory; 
+            if(!this.WizdomContext.isWizdomSaaS) {
+                wizdomCorsProxyServiceFactory = new WizdomCorsProxyServiceFactory(this.WizdomContext, this.spContext.pageContext.site.absoluteUrl, this.spContext.pageContext.user.loginName);        
+                this.WizdomCorsProxyService = wizdomCorsProxyServiceFactory.GetOrCreate();                        
+            
                 // When cors proxy initialized successfully
-                var wizdomLanguageUpdate = new WizdomLanguageUpdate(new SpfxHttpClient(this.spContext.httpClient), this.WizdomWebApiService, this.Cache);
-                wizdomLanguageUpdate.UpdateIfNeededAsync(this.spContext.web.absoluteUrl, this.WizdomCorsProxyService.corsProxyState.currentUserLanguage);
-            });
+                this.WizdomCorsProxyService.AddHandler("WizdomCorsProxySuccess", updateWizdomLanguage);
+            }
+
+            var wizdomWebApiServiceFactory = new WizdomWebApiServiceFactory(wizdomCorsProxyServiceFactory, this.WizdomContext, this.spContext, aadHttpClientPromise);
+            this.WizdomWebApiService = await wizdomWebApiServiceFactory.Create();
+
+            if(this.WizdomContext.isWizdomSaaS) {
+                window["WizdomCorsProxyState"] = window["WizdomCorsProxyState"] || {            
+                    session: "", 
+                    msLeftOnToken: 0, 
+                    allWizdomRoles: this.WizdomContext.serverContext.allWizdomRoles, 
+                    rolesForCurrentUser: this.WizdomContext.serverContext.rolesForCurrentUser, 
+                    upgradeInProgress: false,
+                    currentUserLanguage: this.WizdomContext.serverContext.currentUserLanguage,
+                    corsProxyFailed: false
+                } as IWizdomCorsProxySharedState;
+
+                updateWizdomLanguage();
+            }
+            
 
             await Promise.all([translationServicePromise, configurationPromise]);
         } catch(ex) {
-            if(console.exception != null)
-                console.exception("wizdom-intranet/services initializing error", ex);            
-        }                   
+            if(console.error != null)
+                console.error("wizdom-intranet/services initializing error", ex);            
+        }
+        return;        
     }
 }


### PR DESCRIPTION
Version bump to 2.0.0 adding support for Wizdom SaaS
Graceful fallback to non-SaaS is implemented as much as possible but there might be a few gaps.
To support Wizdom SaaS webparts need to add 
```JSON
    "webApiPermissionRequests": [
            {
                "scope": "user_impersonation",
                "resource": "Wizdom Unified Gateway"
            }
        ],
```

to their package-solution.json file